### PR TITLE
build: ➕ add @types/unist 📦

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             ${{ runner.os }}-
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 6.29.1
+          version: 7.5.0
       - run: pnpm install
       - run: pnpm run type --filter ./packages/blog2
       - run: pnpm run test --filter ./packages/blog2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           version: 7.5.0
       - run: pnpm install
-      - run: pnpm run type --filter ./packages/blog2
-      - run: pnpm run test --filter ./packages/blog2
+      - run: pnpm --filter blog2 run type
+      - run: pnpm --filter blog2 run test
 

--- a/.github/workflows/node_modules.yml
+++ b/.github/workflows/node_modules.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 6.29.1
+          version: 7.5.0
       - run: pnpm install
       - name: main node_modules
         id: main_node_modules

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 6.29.1
+          version: 7.5.0
       - run: pnpm install
       - name: Build
         run: pnpm --filter blog2 run build

--- a/packages/blog2/README.md
+++ b/packages/blog2/README.md
@@ -13,7 +13,7 @@ pnpm install
 To be able to run the project, you run dev server
 
 ```bash
-pnpm run dev --filter ./packages/blog2
+pnpm --filter blog2 run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/blog2/package.json
+++ b/packages/blog2/package.json
@@ -34,6 +34,7 @@
     "@types/mocha": "9.1.1",
     "@types/node": "*",
     "@types/react": "18.0.14",
+    "@types/unist": "2.0.6",
     "bundlewatch": "0.3.3",
     "csstype": "3.1.0",
     "earljs": "0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ importers:
       '@types/mocha': 9.1.1
       '@types/node': '*'
       '@types/react': 18.0.14
+      '@types/unist': 2.0.6
       bundlewatch: 0.3.3
       csstype: 3.1.0
       earljs: 0.2.3
@@ -59,6 +60,7 @@ importers:
       '@types/mocha': 9.1.1
       '@types/node': 17.0.7
       '@types/react': 18.0.14
+      '@types/unist': 2.0.6
       bundlewatch: 0.3.3
       csstype: 3.1.0
       earljs: 0.2.3_typescript@4.7.4


### PR DESCRIPTION
## What

Add types for `unist`

## Why

Fix typecheck for https://github.com/Beraliv/beraliv.dev/pull/469

```bash
Run pnpm run type --filter ./packages/blog2
 ERR_PNPM_NO_SCRIPT  Missing script: type
Error: Process completed with exit code 1.
```