### PR TITLE
docs: 📄 update Chainable Options solution

### DIFF
--- a/packages/blog2/next.config.js
+++ b/packages/blog2/next.config.js
@@ -32,6 +32,11 @@ const config = {
         destination: "/2021-07-05-spread-in-typescript",
         permanent: true,
       },
+      {
+        source: "/2021-04-28-mapped-types-in-functions",
+        destination: "/2021-04-28-chainable-options",
+        permanent: true,
+      },
     ];
   },
   async rewrites() {

--- a/packages/blog2/src/cache/imageMetadata.json
+++ b/packages/blog2/src/cache/imageMetadata.json
@@ -291,26 +291,6 @@
     "width": 924,
     "height": 364
   },
-  "/mapped-types-in-functions/step1-example-of-use.png": {
-    "width": 1236,
-    "height": 748
-  },
-  "/mapped-types-in-functions/step2-chainable-return-type.png": {
-    "width": 916,
-    "height": 468
-  },
-  "/mapped-types-in-functions/step3-add-generic-type.png": {
-    "width": 916,
-    "height": 468
-  },
-  "/mapped-types-in-functions/step4-add-key-and-value-for-every-option-call.png": {
-    "width": 1232,
-    "height": 468
-  },
-  "/mapped-types-in-functions/step5-solution.png": {
-    "width": 1452,
-    "height": 468
-  },
   "/omit-under-the-hood/step1-example-of-use.png": {
     "width": 1324,
     "height": 714
@@ -920,6 +900,10 @@
     "height": 1800
   },
   "/camel-case/image2.png": {
+    "width": 1600,
+    "height": 900
+  },
+  "/chainable-options/image.png": {
     "width": 1600,
     "height": 900
   }

--- a/packages/blog2/src/content/2021-04-28-chainable-options.md
+++ b/packages/blog2/src/content/2021-04-28-chainable-options.md
@@ -8,7 +8,7 @@ keywords:
   - typescript
   - challenges
   - chainable options
-image: /mapped-types-in-functions/step1-example-of-use.png
+image: /chainable-options/image.png
 ---
 
 ```typescript title="Example of Chainable Options use"

--- a/packages/blog2/src/content/2021-04-28-chainable-options.md
+++ b/packages/blog2/src/content/2021-04-28-chainable-options.md
@@ -1,5 +1,5 @@
 ---
-title: Mapped Types in functions
+title: Chainable Options
 date: "2021-04-28"
 description: Given API, collect the object with keys and values after each call
 labels:
@@ -7,6 +7,7 @@ labels:
 keywords:
   - typescript
   - challenges
+  - chainable options
 image: /mapped-types-in-functions/step1-example-of-use.png
 ---
 

--- a/packages/blog2/src/content/2021-04-28-chainable-options.md
+++ b/packages/blog2/src/content/2021-04-28-chainable-options.md
@@ -147,6 +147,8 @@ const handleTestCommand = (config: TestCommandConfig): void => {
 };
 ```
 
+The whole `yargs` example is available here – https://tsplay.dev/wXQJ1N 👏
+
 We correctly infer `string | undefined` for known options and `unknown` for unknown option ✅
 
 Have a nice day ☀️

--- a/packages/blog2/src/content/2021-04-28-chainable-options.md
+++ b/packages/blog2/src/content/2021-04-28-chainable-options.md
@@ -132,6 +132,8 @@ type Test = {
 };
 ```
 
+We improved the readability of inferred value, you can see the updated `Chainable` type in Playground – https://tsplay.dev/w1PMGW
+
 ## Real-life example
 
 You can find chainable options in [yargs](https://www.npmjs.com/package/yargs) when you create a CLI in node.js

--- a/packages/blog2/src/content/2021-04-28-chainable-options.md
+++ b/packages/blog2/src/content/2021-04-28-chainable-options.md
@@ -87,7 +87,7 @@ Don't forget to check the solution in Playground – https://tsplay.dev/mLqMAW
 
 ## Improve readability
 
-If you hover over `result`, you will see it:
+If you create `type Test = typeof result` and hover over `Test`, you will see this:
 
 ```typescript title="Inferred type for result"
 const result: Record<"foo", number> &
@@ -102,7 +102,7 @@ const result: Record<"foo", number> &
 
 That happens because we use [Intersection types](https://www.typescriptlang.org/docs/handbook/2/objects.html#intersection-types), or in other words `&`.
 
-We will use [Mapped types](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html) to add key and value without `&`:
+We can use [Mapped types](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html) to add key and value without `&`:
 
 ```typescript title="Hack with Flatten type"
 type AddOption<ParsedConfig, Key extends string, Value> = {
@@ -120,7 +120,7 @@ interface Chainable<ParsedConfig = {}> {
 }
 ```
 
-Now if we add `type Test = typeof result;` and hover over it, we will see:
+Now if we hover over `Test` again, we will see:
 
 ```typescript title="Updated inferred type for result"
 type Test = {
@@ -136,9 +136,9 @@ We improved the readability of inferred value, you can see the updated `Chainabl
 
 ## Real-life example
 
-You can find chainable options in [yargs](https://www.npmjs.com/package/yargs) when you create a CLI in node.js
+You can find chainable options in [yargs](https://www.npmjs.com/package/yargs) – the node.js library to create a CLI for your needs.
 
-For example, you need to create a command `test` which can accept optional `testDir`, `ip` and `testCount` options:
+For example, when you need to create a command `test` which can accept optional `testDir`, `ip` and `testCount` options, you can define it this way:
 
 ```typescript title="Test command which accepts 3 optional options"
 import * as yargs from "yargs";
@@ -166,9 +166,9 @@ yargs.command(
 );
 ```
 
-And then we need to define `handleTestCommand` where `config` is infered from options that we included in `buildTestCommand`.
+Then we will need to define `handleTestCommand` where `config` is inferred from options that we included in `buildTestCommand`.
 
-I will show the solution for it as is:
+How can we do it? I will show the solution for it as is:
 
 ```typescript title="Infer command config out of build function"
 type AnyFunction = (...args: any[]) => any;
@@ -201,6 +201,6 @@ const handleTestCommand = (config: TestCommandConfig): void => {
 
 The whole `yargs` example is available here – https://tsplay.dev/wXQJ1N 👏
 
-We correctly infer `string | undefined` for known options and `unknown` for unknown option ✅
+We correctly inferred `string | undefined` for known options and `unknown` for unknown option ✅
 
-Have a nice day ☀️
+Thank you for your time and have a nice day ☀️

--- a/packages/blog2/src/content/2021-04-28-mapped-types-in-functions.md
+++ b/packages/blog2/src/content/2021-04-28-mapped-types-in-functions.md
@@ -10,7 +10,23 @@ keywords:
 image: /mapped-types-in-functions/step1-example-of-use.png
 ---
 
-![Example of Chainable Options use](/mapped-types-in-functions/step1-example-of-use.png)
+```typescript title="Example of Chainable Options use"
+interface Chainable {
+  option(key: string, value: any): any; // implementation
+  get(): any;
+}
+
+declare const chainable: Chainable;
+
+const step1 = chainable.option("title", "Mapped Types in functions");
+//    ^? { title: string }
+
+const step2 = step1.option("author", { name: "Alexey" });
+//    ^? { title: string; author: { name: string } }
+
+const result = step2.get();
+//    ^? { title: string; author: { name: string } }
+```
 
 Today we discuss [Chainable Options](https://github.com/type-challenges/type-challenges/blob/master/questions/12-medium-chainable-options/README.md)
 
@@ -22,24 +38,47 @@ But the difference here is that you need to infer type from the calls.
 
 First we can do is to return `Chainable` for a function `option`:
 
-![Change ReturnType for option function](/mapped-types-in-functions/step2-chainable-return-type.png)
+```typescript title="Change ReturnType for option function"
+interface Chainable {
+  option(key: string, value: any): Chainable;
+  get(): any;
+}
+```
 
 Next, we say that we start from an empty object type and call after call we collect the data type in it. Let's add `T` as [Generic](https://www.typescriptlang.org/docs/handbook/2/generics.html):
 
-![Added generic type T](/mapped-types-in-functions/step3-add-generic-type.png)
+```typescript title="Added generic type T"
+interface Chainable<T = {}> {
+  option(key: string, value: any): Chainable;
+  get(): T;
+}
+```
 
 Last but not least is the collection itself. Let's add types for a key and a value as [Generic](https://www.typescriptlang.org/docs/handbook/2/generics.html):
 
-![Add key and value for every option call](/mapped-types-in-functions/step4-add-key-and-value-for-every-option-call.png)
+```typescript title="Add key and value for every option call"
+interface Chainable<T = {}> {
+  option<K, V>(key: K, value: V): Chainable<T & { [Key in K]: V }>;
+  get(): T;
+}
+```
 
-If you check [temporary solution in Playground](https://www.typescriptlang.org/play?#code/PQKgUABBCMBMEFoIGEAWBDAlgO3QIwBsBTCAeQAcAXTAe2wGdJEEXWm8BPCAQW0tTpcAYgFcIACgAC6PgDMRASggBiALZEAJphGqV6cuQKYAxump0mTZdYgBFEUXrnslqGiy5CJGlVoMI6ABOJMY0qqp0BFwi9JoQOBAAUugAbuj0xoGYVAB0EABCIpQQAO6oRNilJPQlmJTGqBCUNBAAKhzkRADKmdmUADQQppUcNGLkgT5EgVFNHSR1APyuEACSlfyY9EMYBMTYAOZEg6Ni2ERxzXOdAZU0eABWRMbFNIEBQwTp20hlZkQpaYQU4QIwAaxISCuExoKUwGhIlBKLXk2BefggAAMfM5xBCOIM0gQHApMbcNFijpRxKS8ussTi-JiTmMhjIIEQAB6UCoU-ghESBYJ8IZ0WSYA7XEicJrlCAHTCAyr48kQIkOPIAdWqAhEBAp+DGxSu6GMxkc235EHFuAIEGC9D1xTh6EpREomJyKyEbw5nPQqkMRBWmNDlEYUARxi+wVFDGKoWw4oOAC4UBgcPhiCtE057Y4nRAALxx5NMKA5Rl0cQAclkNBoNcGcAAzApyxBK75qzXcOomxAa5R5ggGug9hUjvQa+2oBWq9ha3gggOAN5q8cONM1gASRD2LU1b31NYgAF9Z3OclSaStgMA-Z0XrLEfMIDRZPnHQRjS08EQUyYHAeUCWRTRIAAlAsfwgVcO3rGg02wHR-0CDs+wAiAnCyQ4O2XQI0zguc53VTDsJwA4OzPJhqKgUNMRWABNVkNDoIcIHOS4WhKLIeVuLgHnoYBw1BGgFWMJoWgwbANGIF8IBhLxdCQB4YmKBJhxuYhAQIPImNZYYAnoR11FlMwsXxMlIi4U1zSobZMXIw4yRkPk5UxUiyUM-9+M2Q5EAgVS82IVIFmKdIEC2PIugDEhMUs0o2OKHzyG+S5anNL0oCYAA+CAADVMCIEp30qABxOodxEPA01QShKHIegU3vcMGhyQTK0CA5gDgMAQGAMBBtACAAH0xvGibxogZjBRQGgEQgPdY0mlaxogfqhofTSSHcTMvAAHlaYtYLPPKSzg+85wXfaAGlBnynK8SIDg0zujdiUw-KFDTXbPGIQ6IAAMlgiAAG0boAXTTfKAG5zxymGwEuqAb2+tokYfaiwG29MPCzIgAfO07jqI99u2wW77se-FXsJTdPrR378YB4H13B574kqSHofhxGUfdGk01aRGseG1aVraRximQdJHFG8WJvWgbMEDN5inXbhwWOCAAFFOSfYoz2tSZdBrSRttHXZ9inYAikwAhp0GqMYxCOg83QH6Mz+4MwFzYoHULEt0CYLtcTrBsB1bS9Q78JcV0GddSO3PcDwgI8Zg0U8LxDhdawwgchxHMcJ0ORwZxD1HBpx0xYm2EtQaYPWDf2zXMAhfbto-L8nUGJvnh5DQcpysAIart8+5eOJzqYBCkJQ6Z2CCQiOyTrDKBwyioFojjYrTJzKKxoaQHlhW1tEQJ+XeLoeUak-T6VpHwCgPKugwWNTneegaGJZwmogOqGpNRahkVA7V6CdW6nAYAMgagL2fgVIqJUv4-z8H-ABjVmrCRAWAiBPVYDAGQXbN2uUIAAFk3g7StpORwtV6oYOAW1DqbxKIbTAEAA), you will see that `Type 'K' is not assignable to type 'string | number | symbol'`
+If you check temporary solution in Playground (https://tsplay.dev/m3PZAW), you will see that `Type 'K' is not assignable to type 'string | number | symbol'`
 
 It means we need to apply [Generic Constrain](https://www.typescriptlang.org/docs/handbook/2/generics.html#generic-constraints) for `K`, it should be a `string`:
 
-![Solution](/mapped-types-in-functions/step5-solution.png)
+```typescript title="Solution"
+interface Chainable<T = {}> {
+  option<K extends string, V>(
+    key: K,
+    value: V
+  ): Chainable<T & { [Key in K]: V }>;
+  get(): T;
+}
+```
 
 That's it 💪
 
-Don't forget to check [the solution in Playground](https://www.typescriptlang.org/play?#code/PQKgUABBCMBMEFoIGEAWBDAlgO3QIwBsBTCAeQAcAXTAe2wGdJEEXWm8BPCAQW0tTpcAYgFcIACgAC6PgDMRASggBiALZEAJphGqV6cuQKYAxump0mTZdYgBFEUXrnslqGiy5CJGlVoMI6ABOJMY0qqp0BFwi9JoQOBAAUugAbuj0xoGYVAB0EABCIpQQAO6oRNilJPQlmJTGqBCUNBAAKhzkRADKmdmUADQQppUcNGLkgT5EgVFNHSR1APyuEACSlfyY9EMYBMTYAOZEg6Ni2ERxzXOdAZU0eABWRMbFNIEBQwTp20hlZkQpaYQU4QIwAaxISCuExoKUwGhIlBKLXk2BefggAAMfM5xBCOIM0gQHApMbcNFijpRxKS8ussTi-JiTmMhjIIEQAB6UCoU-ghESBYJ8IZ0WSYA7XEicJrlCAHTCAyr48kQIkOPIAdWqAhEBAp+DGxSu6GMxkc235EHFuAIEGC9D1xTh6EpREomJyKyEbw5nPQqkMRBWmNDlEYUARxi+wVFDGKoWw4oOAC4UBgcPhiCtE057Y4nRAALxx5NMKA5Rl0cQAclkNBoNcGcAAzApyxBK75qzXcOomxAa5R5ggGug9hUjvQa+2oBWq9ha3gggOAN5q8cONM1gASRD2LU1b31NYgAF9Z3OclSaStgMA-Z0XrLEfMIDRZPnHQRjS08EQUyYHAeUCWRTRIAAlAsfwgVcO3rGg02wHR-0CDs+wAiAnCyQ4O2XQI0zguc53VTDsJwA4OzPJhqKgUNMRWABNVkNDoIcIHOS4WhKLIeVuLgHnoYBw1BGgFWMJoWgwbANGIF8IBhLxdCQB4YmKBJhxuYhAQIPImNZYYAnoR11FlMwsXxMlIi4U1zSobZMXIw4yRkPk5UxUiyUM-9+M2Q5EAgVS82IVIFmKdIEC2PIugDEhMUs0o2OKHzyG+S5anNL0oCYAA+CAADVMCIEp30qABxOodxEPA01QShKHIegU3vcMGhyQTK0CA5gDgMAQGAMBBtACAAH0xvGibxogZjBRQGgEQgPdY0mlaxogfqhofTSSHcTMvAAHlaYtYLPPKSzg+85wXfaAGlBnynK8SIDg0zujdiUw-KFDTXbPGIQ6IAAMlgiAAG0boAXTTfKAG5zxymGwEuqAb2+tokYfaiwG29MPCzIgAfO07jqI99u2wW6-R5GTticg57se-FXsJTdPrR378YB4H13B574kqSHofhxGUfdGk01aRGseG1aVraRximQdJHFG2WJvWgbMEDN5inXbhwWOCAAFFOSfYoz2tSZdBrSRttHXZ9inYAikwAhp0GqMYxCOg83QH6Mz+4MwFzYoHULEt0CYLtcTrBsB1bS9o78JcV0GddSO3PcDwgI8Zg0U8LyjhdawwgchxHMcJ0ORwZyj1HBpx0xYm2EtQaYE2zf2-XMAhfbto-L8nUGDvnh5DQcpysAIYbt8R5eOJzqYBCkJQ6Z2CCQiOwzrDKBwyioFojjYrTOmwCxoaQFVtW1tEQJ+XeLoeUaq-r41pHwCgPKugwWNTneegaDEmcE1CAdUGpNRahkVA7V6CdW6nAYAMgahr0-gVIqJUAFAL8CAsBjVmrCSgTAuBPVYDAEwS7H2uUIAAFk3g7QdpORwtV6p4MgW1DqbxKIbTAEAA)
+Don't forget to check the solution in Playground – https://tsplay.dev/wXQ6kN
 
 Have a nice day ☀️

--- a/packages/blog2/src/functions/getAllPosts/index.test.ts
+++ b/packages/blog2/src/functions/getAllPosts/index.test.ts
@@ -30,7 +30,7 @@ describe(getAllPosts.name, () => {
       "2021-04-23-partial-readonly",
       "2021-04-25-recursive-readonly-for-objects",
       "2021-04-27-making-union-out-of-tuple",
-      "2021-04-28-mapped-types-in-functions",
+      "2021-04-28-chainable-options",
       "2021-04-29-infer-last-element",
       "2021-05-01-manipulation-with-tuple-elements",
       "2021-05-04-promise-all-under-the-hood",


### PR DESCRIPTION
## What

1. Replace images with code chunks ✅
2. Add example `yargs` as it has built-in chainable options for config ✅
3. Rename the challenge name (Chainable Options is a clear name) ✅
4. Redirect old paths to new one (e.g. from `/2021-04-28-mapped-types-in-functions` to `/2021-04-28-chainable-options`) in Next.js ✅
5. Improve readability of inferred type ✅
6. Update SEO image ✅

## Why

1. You can copy/paste examples from the blog
2. The example shows the power of this challenge