### PR TITLE
build: 📦 use pnpm@7.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             ${{ runner.os }}-
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 7.6.0
+          version: 7.9.0
       - run: pnpm install
       - run: pnpm --filter blog2 run type
       - run: pnpm --filter blog2 run test

--- a/.github/workflows/node_modules.yml
+++ b/.github/workflows/node_modules.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 7.6.0
+          version: 7.9.0
       - run: pnpm install
       - name: main node_modules
         id: main_node_modules

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 7.6.0
+          version: 7.9.0
       - run: pnpm install
       - name: Build
         run: pnpm --filter blog2 run build


### PR DESCRIPTION
## What

Update `pnpm` version

## Why

To sync local environment with remote (I use `pnpm@7.9.0` now)

## Additional information

pnpm 7.9.0 release notes – https://github.com/pnpm/pnpm/releases/tag/v7.9.0