### PR TITLE
feat: Highlight tennis player path in draws

### DIFF
--- a/packages/tennis-tournaments/src/MatchCard.module.css
+++ b/packages/tennis-tournaments/src/MatchCard.module.css
@@ -6,10 +6,11 @@
   box-shadow: 0 0 30px 0 #e1e1e1;
   border: 1px solid #f4f4f4;
   background-color: #f4f4f4;
+
+  cursor: pointer;
 }
 
 .MatchCardWithShortScore:hover {
-  cursor: pointer;
   opacity: 0.6;
 }
 

--- a/packages/tennis-tournaments/src/MatchCard.module.css
+++ b/packages/tennis-tournaments/src/MatchCard.module.css
@@ -2,11 +2,9 @@
   position: relative;
   height: inherit;
   width: 305px;
-  padding: 2px 12px;
 
   box-shadow: 0 0 30px 0 #e1e1e1;
   border: 1px solid #f4f4f4;
-  border-radius: 3px;
   background-color: #f4f4f4;
 }
 
@@ -34,11 +32,4 @@
 
 .Home {
   border-bottom: 1px solid #e8e8e8;
-}
-
-.Home,
-.Away {
-  margin-top: 8px;
-  /* use padding instead of margin to have indent between border and PlayerMatchResult */
-  padding-bottom: 10px;
 }

--- a/packages/tennis-tournaments/src/MatchCard.module.css
+++ b/packages/tennis-tournaments/src/MatchCard.module.css
@@ -3,7 +3,6 @@
   height: inherit;
   width: 305px;
 
-  box-shadow: 0 0 30px 0 #e1e1e1;
   border: 1px solid #f4f4f4;
   background-color: #f4f4f4;
 

--- a/packages/tennis-tournaments/src/MatchCard.tsx
+++ b/packages/tennis-tournaments/src/MatchCard.tsx
@@ -91,19 +91,19 @@ const MatchCard: Component<MatchCardProps> = ({
         className={styles.Home}
         courtType={courtType}
         isInProgress={isInProgress}
-        isSelected={() => selectedTennisPlayerId() === homePlayer.id}
         isWinner={isHomeWinner}
         onSelect={selectTennisPlayerId}
         player={homePlayer}
         playerCentricSets={homeCentricSets}
+        selectedPlayerId={selectedTennisPlayerId}
       />
       <PlayerMatchResult
         courtType={courtType}
-        isSelected={() => selectedTennisPlayerId() === awayPlayer.id}
         isWinner={isAwayWinner}
         onSelect={selectTennisPlayerId}
         player={awayPlayer}
         playerCentricSets={awayCentricSets}
+        selectedPlayerId={selectedTennisPlayerId}
       />
     </div>
   );

--- a/packages/tennis-tournaments/src/MatchCard.tsx
+++ b/packages/tennis-tournaments/src/MatchCard.tsx
@@ -3,6 +3,7 @@ import {
   type Component,
   createSignal,
   createEffect,
+  Signal,
 } from "solid-js";
 
 import styles from "./MatchCard.module.css";
@@ -20,6 +21,7 @@ interface MatchCardProps {
   courtType: CourtType;
   eventId: string | undefined;
   homePlayer: TennisPlayer;
+  selectedTennisPlayerIdSignal: Signal<TennisPlayer["id"] | undefined>;
   sets: TennisSet[];
   status: MatchStatus;
 }
@@ -29,6 +31,7 @@ const MatchCard: Component<MatchCardProps> = ({
   courtType,
   eventId,
   homePlayer,
+  selectedTennisPlayerIdSignal,
   sets,
   status,
 }) => {
@@ -72,6 +75,9 @@ const MatchCard: Component<MatchCardProps> = ({
   const isAwayWinner = status.type === "FINISHED" && status.winner === "away";
   const isInProgress = status.type === "IN_PROGRESS";
 
+  const [selectedTennisPlayerId, selectTennisPlayerId] =
+    selectedTennisPlayerIdSignal;
+
   return (
     <div
       class={classNames(styles.MatchCard, {
@@ -84,15 +90,18 @@ const MatchCard: Component<MatchCardProps> = ({
       <PlayerMatchResult
         className={styles.Home}
         courtType={courtType}
-        isWinner={isHomeWinner}
         isInProgress={isInProgress}
+        isSelected={() => selectedTennisPlayerId() === homePlayer.id}
+        isWinner={isHomeWinner}
+        onSelect={selectTennisPlayerId}
         player={homePlayer}
         playerCentricSets={homeCentricSets}
       />
       <PlayerMatchResult
-        className={styles.Away}
         courtType={courtType}
+        isSelected={() => selectedTennisPlayerId() === awayPlayer.id}
         isWinner={isAwayWinner}
+        onSelect={selectTennisPlayerId}
         player={awayPlayer}
         playerCentricSets={awayCentricSets}
       />

--- a/packages/tennis-tournaments/src/PlayerMatchResult.module.css
+++ b/packages/tennis-tournaments/src/PlayerMatchResult.module.css
@@ -2,6 +2,25 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  /* use padding-bottom instead of margin to have indent between border and PlayerMatchResult */
+  padding: 9px 12px 11px 12px;
+}
+
+.Selected {
+  color: white;
+}
+
+.grass.Selected {
+  background-color: #405e54;
+}
+
+.clay.Selected {
+  background-color: #993300;
+}
+
+.hard.Selected {
+  background-color: #2d5986;
 }
 
 .Player {
@@ -60,7 +79,7 @@
 }
 
 .grass .Winner svg path {
-  fill: #639080;
+  fill: #405e54;
 }
 
 .clay .Winner svg path {
@@ -68,7 +87,11 @@
 }
 
 .hard .Winner svg path {
-  fill: #336699;
+  fill: #2d5986;
+}
+
+.Selected .Winner svg path {
+  fill: white;
 }
 
 .Winner,

--- a/packages/tennis-tournaments/src/PlayerMatchResult.module.css
+++ b/packages/tennis-tournaments/src/PlayerMatchResult.module.css
@@ -5,6 +5,14 @@
 
   /* use padding-bottom instead of margin to have indent between border and PlayerMatchResult */
   padding: 9px 12px 11px 12px;
+
+  /* prevents unintentional player names select */
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }
 
 .Selected {

--- a/packages/tennis-tournaments/src/PlayerMatchResult.tsx
+++ b/packages/tennis-tournaments/src/PlayerMatchResult.tsx
@@ -15,26 +15,32 @@ interface PlayerMatchResultProps {
   className?: string;
   courtType: CourtType;
   isInProgress?: boolean;
-  isSelected: Accessor<boolean>;
   isWinner: boolean;
-  onSelect: Setter<TennisPlayer["id"]>;
+  onSelect: Setter<TennisPlayer["id"] | undefined>;
   player: TennisPlayer;
   playerCentricSets: Accessor<TennisSet[]>;
+  selectedPlayerId: Accessor<TennisPlayer["id"] | undefined>;
 }
 
 const PlayerMatchResult: Component<PlayerMatchResultProps> = ({
   className,
   courtType,
   isInProgress = false,
-  isSelected,
   isWinner,
   onSelect,
   player,
   playerCentricSets,
+  selectedPlayerId,
 }) => {
   const shortName = createShortName(player);
-
-  const selectPlayerId = () => onSelect(player.id);
+  const isCurrentPlayerSelected = () => selectedPlayerId() === player.id;
+  const handlePlayerIdUpdate = () => {
+    if (isCurrentPlayerSelected()) {
+      onSelect(undefined);
+    } else {
+      onSelect(player.id);
+    }
+  };
 
   return (
     <div
@@ -43,10 +49,10 @@ const PlayerMatchResult: Component<PlayerMatchResultProps> = ({
         [styles.grass]: courtType === "grass",
         [styles.clay]: courtType === "clay",
         [styles.hard]: courtType === "hard",
-        [styles.Selected]: isSelected(),
+        [styles.Selected]: isCurrentPlayerSelected(),
       })}
-      onClick={selectPlayerId}
-      onTouchStart={selectPlayerId}
+      onClick={handlePlayerIdUpdate}
+      onTouchStart={handlePlayerIdUpdate}
     >
       <div class={styles.Player}>
         <div>

--- a/packages/tennis-tournaments/src/PlayerMatchResult.tsx
+++ b/packages/tennis-tournaments/src/PlayerMatchResult.tsx
@@ -1,4 +1,13 @@
-import { For, type Component, Show, Accessor, Signal, Setter } from "solid-js";
+import {
+  For,
+  type Component,
+  Show,
+  Accessor,
+  Setter,
+  onMount,
+  onCleanup,
+  createSignal,
+} from "solid-js";
 
 import styles from "./PlayerMatchResult.module.css";
 import { TennisPlayer } from "./Types/TennisPlayer";
@@ -10,6 +19,7 @@ import { hasTieBreak } from "./Utils/hasTieBreak";
 import { doesWinSet } from "./Utils/doesWinSet";
 import { classNames } from "./Utils/classNames";
 import { CourtType } from "./Types/CourtType";
+import { createOneTouchTapController } from "./Utils/createOneTouchTapController";
 
 interface PlayerMatchResultProps {
   className?: string;
@@ -33,6 +43,7 @@ const PlayerMatchResult: Component<PlayerMatchResultProps> = ({
   selectedPlayerId,
 }) => {
   const shortName = createShortName(player);
+
   const isCurrentPlayerSelected = () => selectedPlayerId() === player.id;
   const togglePlayerId = () => {
     if (isCurrentPlayerSelected()) {
@@ -41,6 +52,39 @@ const PlayerMatchResult: Component<PlayerMatchResultProps> = ({
       onSelect(player.id);
     }
   };
+
+  let playerMatchResultRef: HTMLDivElement;
+
+  const { handleTouchStartEvent, handleTouchEndEvent } =
+    createOneTouchTapController(togglePlayerId);
+
+  onMount(() => {
+    playerMatchResultRef.addEventListener("click", togglePlayerId);
+    playerMatchResultRef.addEventListener(
+      "touchstart",
+      handleTouchStartEvent,
+      false
+    );
+    playerMatchResultRef.addEventListener(
+      "touchend",
+      handleTouchEndEvent,
+      false
+    );
+  });
+
+  onCleanup(() => {
+    playerMatchResultRef.removeEventListener("click", togglePlayerId);
+    playerMatchResultRef.removeEventListener(
+      "touchstart",
+      handleTouchStartEvent,
+      false
+    );
+    playerMatchResultRef.removeEventListener(
+      "touchend",
+      handleTouchEndEvent,
+      false
+    );
+  });
 
   return (
     <div
@@ -51,8 +95,7 @@ const PlayerMatchResult: Component<PlayerMatchResultProps> = ({
         [styles.hard]: courtType === "hard",
         [styles.Selected]: isCurrentPlayerSelected(),
       })}
-      onClick={togglePlayerId}
-      onTouchEnd={togglePlayerId}
+      ref={playerMatchResultRef!}
     >
       <div class={styles.Player}>
         <div>

--- a/packages/tennis-tournaments/src/PlayerMatchResult.tsx
+++ b/packages/tennis-tournaments/src/PlayerMatchResult.tsx
@@ -1,4 +1,4 @@
-import { For, type Component, Show, Accessor } from "solid-js";
+import { For, type Component, Show, Accessor, Signal, Setter } from "solid-js";
 
 import styles from "./PlayerMatchResult.module.css";
 import { TennisPlayer } from "./Types/TennisPlayer";
@@ -15,7 +15,9 @@ interface PlayerMatchResultProps {
   className?: string;
   courtType: CourtType;
   isInProgress?: boolean;
+  isSelected: Accessor<boolean>;
   isWinner: boolean;
+  onSelect: Setter<TennisPlayer["id"]>;
   player: TennisPlayer;
   playerCentricSets: Accessor<TennisSet[]>;
 }
@@ -24,11 +26,15 @@ const PlayerMatchResult: Component<PlayerMatchResultProps> = ({
   className,
   courtType,
   isInProgress = false,
+  isSelected,
   isWinner,
+  onSelect,
   player,
   playerCentricSets,
 }) => {
   const shortName = createShortName(player);
+
+  const selectPlayerId = () => onSelect(player.id);
 
   return (
     <div
@@ -37,7 +43,10 @@ const PlayerMatchResult: Component<PlayerMatchResultProps> = ({
         [styles.grass]: courtType === "grass",
         [styles.clay]: courtType === "clay",
         [styles.hard]: courtType === "hard",
+        [styles.Selected]: isSelected(),
       })}
+      onClick={selectPlayerId}
+      onTouchStart={selectPlayerId}
     >
       <div class={styles.Player}>
         <div>

--- a/packages/tennis-tournaments/src/PlayerMatchResult.tsx
+++ b/packages/tennis-tournaments/src/PlayerMatchResult.tsx
@@ -34,7 +34,7 @@ const PlayerMatchResult: Component<PlayerMatchResultProps> = ({
 }) => {
   const shortName = createShortName(player);
   const isCurrentPlayerSelected = () => selectedPlayerId() === player.id;
-  const handlePlayerIdUpdate = () => {
+  const togglePlayerId = () => {
     if (isCurrentPlayerSelected()) {
       onSelect(undefined);
     } else {
@@ -51,8 +51,8 @@ const PlayerMatchResult: Component<PlayerMatchResultProps> = ({
         [styles.hard]: courtType === "hard",
         [styles.Selected]: isCurrentPlayerSelected(),
       })}
-      onClick={handlePlayerIdUpdate}
-      onTouchStart={handlePlayerIdUpdate}
+      onClick={togglePlayerId}
+      onTouchEnd={togglePlayerId}
     >
       <div class={styles.Player}>
         <div>

--- a/packages/tennis-tournaments/src/RoundsNavigation.module.css
+++ b/packages/tennis-tournaments/src/RoundsNavigation.module.css
@@ -43,7 +43,7 @@
 
 .SelectedRound.grass svg path,
 .Round.grass:hover svg path {
-  fill: #639080;
+  fill: #405e54;
 }
 
 .SelectedRound.clay svg path,
@@ -53,7 +53,7 @@
 
 .SelectedRound.hard svg path,
 .Round.hard:hover svg path {
-  fill: #336699;
+  fill: #2d5986;
 }
 
 .RoundOf64 svg {

--- a/packages/tennis-tournaments/src/RoundsNavigation.module.css
+++ b/packages/tennis-tournaments/src/RoundsNavigation.module.css
@@ -3,6 +3,14 @@
   flex-direction: row;
   justify-content: center;
   margin: 15px;
+
+  /* prevents unintentional round names select */
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }
 
 .Round {

--- a/packages/tennis-tournaments/src/TournamentPage.tsx
+++ b/packages/tennis-tournaments/src/TournamentPage.tsx
@@ -1,4 +1,11 @@
-import { type Component, createResource, Show, For } from "solid-js";
+import {
+  type Component,
+  createResource,
+  Show,
+  For,
+  createSignal,
+  createEffect,
+} from "solid-js";
 
 import styles from "./TournamentPage.module.css";
 import { TournamentRound } from "./TournamentRound";
@@ -14,6 +21,7 @@ import { chooseVisibleTree } from "./Utils/chooseVisibleTree";
 import { CourtType } from "./Types/CourtType";
 
 import BackIcon from "./Icons/BackIcon.svg";
+import { TennisPlayer } from "./Types/TennisPlayer";
 
 const TournamentPage: Component = () => {
   // 1. Choose tournament (no requests on this page)
@@ -97,6 +105,10 @@ const TournamentPage: Component = () => {
     chooseVisibleTree
   );
 
+  // Store signal here to update players in all rounds
+
+  const selectedTennisPlayerIdSignal = createSignal<TennisPlayer["id"]>();
+
   return (
     <div class={styles.TournamentPage}>
       <div class={styles.TournamentPageHeader}>
@@ -152,6 +164,7 @@ const TournamentPage: Component = () => {
           {(roundData, index) => (
             <TournamentRound
               {...roundData}
+              selectedTennisPlayerIdSignal={selectedTennisPlayerIdSignal}
               courtType={courtType}
               index={index()}
             />

--- a/packages/tennis-tournaments/src/TournamentRound.tsx
+++ b/packages/tennis-tournaments/src/TournamentRound.tsx
@@ -1,14 +1,16 @@
-import { type Component, For } from "solid-js";
+import { type Component, For, Signal } from "solid-js";
 
 import styles from "./TournamentRound.module.css";
 import { MatchCard } from "./MatchCard";
 import { classNames } from "./Utils/classNames";
 import { type SimpleTournamentRound } from "./Utils/fetchTournamentTree";
 import { CourtType } from "./Types/CourtType";
+import { TennisPlayer } from "./Types/TennisPlayer";
 
 interface TournamentRoundProps extends SimpleTournamentRound {
   courtType: CourtType;
   index: number;
+  selectedTennisPlayerIdSignal: Signal<TennisPlayer["id"] | undefined>;
 }
 
 const TournamentRound: Component<TournamentRoundProps> = ({
@@ -16,6 +18,7 @@ const TournamentRound: Component<TournamentRoundProps> = ({
   index,
   matches,
   order,
+  selectedTennisPlayerIdSignal,
   title,
 }) => {
   return (
@@ -33,7 +36,11 @@ const TournamentRound: Component<TournamentRoundProps> = ({
       <For each={matches}>
         {(match) => (
           <div class={styles.CardWrapper}>
-            <MatchCard {...match} courtType={courtType} />
+            <MatchCard
+              {...match}
+              courtType={courtType}
+              selectedTennisPlayerIdSignal={selectedTennisPlayerIdSignal}
+            />
           </div>
         )}
       </For>

--- a/packages/tennis-tournaments/src/Utils/createOneTouchTapController.ts
+++ b/packages/tennis-tournaments/src/Utils/createOneTouchTapController.ts
@@ -1,0 +1,39 @@
+const ONE_TOUCH_TAP_DIFF_IN_PX = 20;
+
+const createOneTouchTapController = (action: () => void) => {
+  let lastClientX: number = -1;
+  let lastClientY: number = -1;
+
+  const handleTouchStartEvent = (event: TouchEvent) => {
+    lastClientX = event.touches[0].clientX;
+    lastClientY = event.touches[0].clientY;
+  };
+
+  const handleTouchEndEvent = (event: TouchEvent) => {
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+
+    const clientX = event.changedTouches[0].clientX;
+    const clientY = event.changedTouches[0].clientY;
+
+    // one touch tap detected
+
+    if (
+      Math.abs(clientX - lastClientX) <= ONE_TOUCH_TAP_DIFF_IN_PX &&
+      Math.abs(clientY - lastClientY) <= ONE_TOUCH_TAP_DIFF_IN_PX
+    ) {
+      action();
+    }
+
+    lastClientX = -1;
+    lastClientY = -1;
+  };
+
+  return {
+    handleTouchStartEvent,
+    handleTouchEndEvent,
+  };
+};
+
+export { createOneTouchTapController };


### PR DESCRIPTION
## What

- Highlighted tennis player path in draws
- Adjusted colours to meet [contrast checker](https://webaim.org/resources/contrastchecker/) – darker green and blue for grass and hard court types
- Remove shadows for match cards to meet the common style
- Added one touch tap controller to select players and load full score on touch devices

## Why

To be able to follow other matches of the same player in draws

## How

<img width="1242" alt="project-draws-player-navigation-v1" src="https://github.com/Beraliv/beraliv.dev/assets/2991847/b71e91a7-e2f0-44f6-8d74-d3db2b7c441d">
