### PR TITLE
style: ➕ add break-word for links and headers 💅

### DIFF
--- a/packages/blog2/src/components/mdx/MdxHeader/index.module.css
+++ b/packages/blog2/src/components/mdx/MdxHeader/index.module.css
@@ -2,6 +2,7 @@
   position: relative;
   /* half of the size for link icon */
   margin-left: 10px;
+  word-wrap: break-word;
 }
 
 .icon {

--- a/packages/blog2/src/components/mdx/MdxLink/index.module.css
+++ b/packages/blog2/src/components/mdx/MdxLink/index.module.css
@@ -1,0 +1,3 @@
+.link {
+  word-wrap: break-word;
+}

--- a/packages/blog2/src/components/mdx/MdxLink/index.tsx
+++ b/packages/blog2/src/components/mdx/MdxLink/index.tsx
@@ -1,4 +1,5 @@
 import { FC, PropsWithChildren } from "react";
+import styles from "./index.module.css";
 
 interface MdxLinkPropsType {
   href: string;
@@ -9,11 +10,20 @@ export const MdxLink: FC<PropsWithChildren<MdxLinkPropsType>> = ({
   href,
 }) => {
   if (href.startsWith("/") || href.startsWith("#")) {
-    return <a href={href}>{children}</a>;
+    return (
+      <a className={styles.link} href={href}>
+        {children}
+      </a>
+    );
   }
 
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer">
+    <a
+      className={styles.link}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       {children}
     </a>
   );


### PR DESCRIPTION
- Added `break-word` to MdxLink and MdxHeader (h1 to h6)