### PR TITLE
style: Make a compact post preview for blog posts

### DIFF
--- a/packages/blog2/public/rss.xml
+++ b/packages/blog2/public/rss.xml
@@ -29,7 +29,7 @@
             <pubDate>Sat, 10 Sep 2022 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[CamelCase]]></title>
+            <title><![CDATA[Transform string literal type into camelCase in TypeScript]]></title>
             <description><![CDATA[Given a string in any case, returns a string in camel case]]></description>
             <link>https://blog.beraliv.dev/2022-07-14-camel-case</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2022-07-14-camel-case</guid>
@@ -37,7 +37,7 @@
             <pubDate>Thu, 14 Jul 2022 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Advanced types / Holy.js notes]]></title>
+            <title><![CDATA[Advanced types / Holy.js 2021 notes]]></title>
             <description><![CDATA[The power of TypeScript will be revealed by the example of several tasks from type-challenges of the hard level.]]></description>
             <link>https://blog.beraliv.dev/2021-12-10-advanced-types-holyjs-notes</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-12-10-advanced-types-holyjs-notes</guid>
@@ -45,7 +45,7 @@
             <pubDate>Fri, 10 Dec 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[GetOptional]]></title>
+            <title><![CDATA[Extract object type with optional fields in TypeScript]]></title>
             <description><![CDATA[Given an object, returns object with all optional fields]]></description>
             <link>https://blog.beraliv.dev/2021-12-07-get-optional</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-12-07-get-optional</guid>
@@ -53,7 +53,7 @@
             <pubDate>Tue, 07 Dec 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[StringToNumber]]></title>
+            <title><![CDATA[Convert string literal type into number literal type in TypeScript]]></title>
             <description><![CDATA[Given a number as string literal type, returns a number as number literal type]]></description>
             <link>https://blog.beraliv.dev/2021-12-03-string-to-number</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-12-03-string-to-number</guid>
@@ -61,7 +61,7 @@
             <pubDate>Fri, 03 Dec 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Split]]></title>
+            <title><![CDATA[Split string literal type in TypeScript]]></title>
             <description><![CDATA[Given a string and a separator, returns an array or a tuple with the substrings between the separator]]></description>
             <link>https://blog.beraliv.dev/2021-11-29-split</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-11-29-split</guid>
@@ -69,7 +69,7 @@
             <pubDate>Mon, 29 Nov 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Tuple Filter]]></title>
+            <title><![CDATA[Filter tuple type in TypeScript]]></title>
             <description><![CDATA[Given a tuple and a filter, returns the tuple without elements that are part of the filter]]></description>
             <link>https://blog.beraliv.dev/2021-11-27-tuple-filter</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-11-27-tuple-filter</guid>
@@ -77,15 +77,15 @@
             <pubDate>Sat, 27 Nov 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Spread in Object types]]></title>
-            <description><![CDATA[Given two objects, returns the object which is formed as a spread of two objects]]></description>
+            <title><![CDATA[TypeScript spread operator for 2 object types]]></title>
+            <description><![CDATA[Given two objects, returns the object which is formed as a spread of two objects in TypeScript]]></description>
             <link>https://blog.beraliv.dev/2021-07-05-spread-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-07-05-spread-in-typescript</guid>
             <dc:creator><![CDATA[Alexey Berezin]]></dc:creator>
             <pubDate>Mon, 05 Jul 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Absolute]]></title>
+            <title><![CDATA[Math.abs for string literal type in TypeScript]]></title>
             <description><![CDATA[Given a number as a string, return its absolute value as a string too]]></description>
             <link>https://blog.beraliv.dev/2021-06-21-absolute-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-06-21-absolute-in-typescript</guid>
@@ -93,7 +93,7 @@
             <pubDate>Mon, 21 Jun 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Making Union out of string]]></title>
+            <title><![CDATA[Transform string literal type into union of characters in TypeScript]]></title>
             <description><![CDATA[Given a string, return a union of all characters from the string]]></description>
             <link>https://blog.beraliv.dev/2021-06-19-making-union-out-of-string</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-06-19-making-union-out-of-string</guid>
@@ -101,7 +101,7 @@
             <pubDate>Sat, 19 Jun 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Append to Object]]></title>
+            <title><![CDATA[Append key-value pair to object type in TypeScript]]></title>
             <description><![CDATA[We have spread on objects in JavaScript so we can add value by the specified key, let's find out how to do that in TypeScript.]]></description>
             <link>https://blog.beraliv.dev/2021-06-16-append-to-object</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-06-16-append-to-object</guid>
@@ -109,7 +109,7 @@
             <pubDate>Wed, 16 Jun 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Flatten Tuple Type]]></title>
+            <title><![CDATA[Flatten tuple type of tuples in TypeScript]]></title>
             <description><![CDATA[Given the tuple, make it flatten as Array.prototype.flat when pass Infinity]]></description>
             <link>https://blog.beraliv.dev/2021-06-13-flatten-tuple-type-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-06-13-flatten-tuple-type-in-typescript</guid>
@@ -117,7 +117,7 @@
             <pubDate>Sun, 13 Jun 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Length of String]]></title>
+            <title><![CDATA[Infer string length in TypeScript]]></title>
             <description><![CDATA[Given the string, calculate its length. Also try to find the maximum computable string length having a limit of recursive calls]]></description>
             <link>https://blog.beraliv.dev/2021-05-31-string-length-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-31-string-length-in-typescript</guid>
@@ -125,7 +125,7 @@
             <pubDate>Mon, 31 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Permutations]]></title>
+            <title><![CDATA[Calculate all permutations of union type in TypeScript]]></title>
             <description><![CDATA[Given a union, return a union of tuples with all possible permutations (all possible positions of elements without repetition)]]></description>
             <link>https://blog.beraliv.dev/2021-05-30-permutations-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-30-permutations-in-typescript</guid>
@@ -133,7 +133,7 @@
             <pubDate>Sun, 30 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Append argument to a function]]></title>
+            <title><![CDATA[Append argument type into function type in TypeScript]]></title>
             <description><![CDATA[Given the function and the type, include the type as the following argument in the list of function arguments]]></description>
             <link>https://blog.beraliv.dev/2021-05-23-append-argument</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-23-append-argument</guid>
@@ -141,7 +141,7 @@
             <pubDate>Sun, 23 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Replace all occurrences in a string]]></title>
+            <title><![CDATA[Replace all occurrences in string literal type in TypeScript]]></title>
             <description><![CDATA[Given the string, replace all string occurrences with specified string]]></description>
             <link>https://blog.beraliv.dev/2021-05-22-replace-all-occurrences-in-a-string-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-22-replace-all-occurrences-in-a-string-in-typescript</guid>
@@ -149,7 +149,7 @@
             <pubDate>Sat, 22 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Replace occurrence in a string]]></title>
+            <title><![CDATA[Replace occurrence in string literal type in TypeScript]]></title>
             <description><![CDATA[Given the string, replace first string occurrence with specified string]]></description>
             <link>https://blog.beraliv.dev/2021-05-17-replace-occurrence-in-a-string-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-17-replace-occurrence-in-a-string-in-typescript</guid>
@@ -157,7 +157,7 @@
             <pubDate>Mon, 17 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Type Aliases for String manipulation]]></title>
+            <title><![CDATA[Intrinsic string manipulation types in TypeScript]]></title>
             <description><![CDATA[Uppercase, Lowercase, Capitalize and Uncapitalize since TypeScript 4.1]]></description>
             <link>https://blog.beraliv.dev/2021-05-14-type-aliases-for-string-manipulation</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-14-type-aliases-for-string-manipulation</guid>
@@ -165,7 +165,7 @@
             <pubDate>Fri, 14 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Trim]]></title>
+            <title><![CDATA[Trim string literal type in TypeScript]]></title>
             <description><![CDATA[Given the string, remove whitespaces from the beginning and the end]]></description>
             <link>https://blog.beraliv.dev/2021-05-11-trim-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-11-trim-in-typescript</guid>
@@ -173,7 +173,7 @@
             <pubDate>Tue, 11 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Trim Left]]></title>
+            <title><![CDATA[Trim left part of string literal type in TypeScript]]></title>
             <description><![CDATA[Given the string, remove whitespaces from the beginning]]></description>
             <link>https://blog.beraliv.dev/2021-05-10-trim-left-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-10-trim-left-in-typescript</guid>
@@ -181,7 +181,7 @@
             <pubDate>Mon, 10 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Opaque Types]]></title>
+            <title><![CDATA[Opaque Types in TypeScript]]></title>
             <description><![CDATA[Structural type system, workaround in TypeScript, unique symbol and code examples]]></description>
             <link>https://blog.beraliv.dev/2021-05-07-opaque-type-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-07-opaque-type-in-typescript</guid>
@@ -189,7 +189,7 @@
             <pubDate>Fri, 07 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Extract under the hood]]></title>
+            <title><![CDATA[Extract under the hood in TypeScript]]></title>
             <description><![CDATA[Given a union of several types, remove those types which doesn't extend the specified structure]]></description>
             <link>https://blog.beraliv.dev/2021-05-06-extract-under-the-hood</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-06-extract-under-the-hood</guid>
@@ -197,7 +197,7 @@
             <pubDate>Thu, 06 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Promise.all under the hood]]></title>
+            <title><![CDATA[Promise.all types under the hood in TypeScript]]></title>
             <description><![CDATA[Given the tuple with Promise elements, return Promise of tuple]]></description>
             <link>https://blog.beraliv.dev/2021-05-04-promise-all-under-the-hood</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-04-promise-all-under-the-hood</guid>
@@ -205,7 +205,7 @@
             <pubDate>Tue, 04 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Manipulation with Tuple elements]]></title>
+            <title><![CDATA[Manipulation with elements of tuple type in TypeScript]]></title>
             <description><![CDATA[Given the tuple, implement Pop, Shift, Push and Unshift methods like Array.prototype has]]></description>
             <link>https://blog.beraliv.dev/2021-05-01-manipulation-with-tuple-elements</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-05-01-manipulation-with-tuple-elements</guid>
@@ -213,7 +213,7 @@
             <pubDate>Sat, 01 May 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Infer last element]]></title>
+            <title><![CDATA[Infer last element of tuple type in TypeScript]]></title>
             <description><![CDATA[Given the tuple, return its last element]]></description>
             <link>https://blog.beraliv.dev/2021-04-29-infer-last-element</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-29-infer-last-element</guid>
@@ -221,7 +221,7 @@
             <pubDate>Thu, 29 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Chainable Options]]></title>
+            <title><![CDATA[Chainable options type in TypeScript]]></title>
             <description><![CDATA[Given API, collect the object with keys and values after each call]]></description>
             <link>https://blog.beraliv.dev/2021-04-28-chainable-options</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-28-chainable-options</guid>
@@ -229,7 +229,7 @@
             <pubDate>Wed, 28 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Making union out of tuple]]></title>
+            <title><![CDATA[Transform tuple type into a union in TypeScript]]></title>
             <description><![CDATA[Given the tuple, return a union of tuple elements]]></description>
             <link>https://blog.beraliv.dev/2021-04-27-making-union-out-of-tuple</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-27-making-union-out-of-tuple</guid>
@@ -237,7 +237,7 @@
             <pubDate>Tue, 27 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Recursive Readonly for objects]]></title>
+            <title><![CDATA[Recursive readonly object type in TypeScript]]></title>
             <description><![CDATA[Given the object, return object where all properties on all levels are readonly]]></description>
             <link>https://blog.beraliv.dev/2021-04-25-recursive-readonly-for-objects</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-25-recursive-readonly-for-objects</guid>
@@ -245,7 +245,7 @@
             <pubDate>Sun, 25 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Partial Readonly]]></title>
+            <title><![CDATA[Conditionally readonly object type in TypeScript]]></title>
             <description><![CDATA[Given the object and a union of properties, return object where those properties are readonly]]></description>
             <link>https://blog.beraliv.dev/2021-04-23-partial-readonly</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-23-partial-readonly</guid>
@@ -253,7 +253,7 @@
             <pubDate>Fri, 23 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Omit under the hood]]></title>
+            <title><![CDATA[Omit type under the hood in TypeScript]]></title>
             <description><![CDATA[Given the object and a union of properties, return the object but without those properties]]></description>
             <link>https://blog.beraliv.dev/2021-04-21-omit-under-the-hood</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-21-omit-under-the-hood</guid>
@@ -261,7 +261,7 @@
             <pubDate>Wed, 21 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[ReturnType under the hood]]></title>
+            <title><![CDATA[ReturnType under the hood in TypeScript]]></title>
             <description><![CDATA[Given the function, we need to extract what it returns]]></description>
             <link>https://blog.beraliv.dev/2021-04-19-return-type-under-the-hood</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-19-return-type-under-the-hood</guid>
@@ -269,7 +269,7 @@
             <pubDate>Mon, 19 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Includes]]></title>
+            <title><![CDATA[Includes type in TypeScript]]></title>
             <description><![CDATA[Given the tuple and the type, return true if the type is an element of the tuple. Otherwise, return false]]></description>
             <link>https://blog.beraliv.dev/2021-04-16-includes-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-16-includes-in-typescript</guid>
@@ -277,7 +277,7 @@
             <pubDate>Fri, 16 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Spread in Tuple types]]></title>
+            <title><![CDATA[TypeScript spread operator for 2 tuple types]]></title>
             <description><![CDATA[Given two tuples, put the elements of both of them into the resulting tuple]]></description>
             <link>https://blog.beraliv.dev/2021-04-15-spread-in-tuple-types-in-typescript</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-15-spread-in-tuple-types-in-typescript</guid>
@@ -285,7 +285,7 @@
             <pubDate>Thu, 15 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Boolean conditional statement]]></title>
+            <title><![CDATA[If statement type in TypeScript]]></title>
             <description><![CDATA[Given the boolean, in case of true return first type, otherwise second one]]></description>
             <link>https://blog.beraliv.dev/2021-04-14-boolean-condition</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-14-boolean-condition</guid>
@@ -293,7 +293,7 @@
             <pubDate>Wed, 14 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Unwrapping Promises]]></title>
+            <title><![CDATA[Awaited type under the hood in TypeScript]]></title>
             <description><![CDATA[Given the promise, return the value after applying await recursively]]></description>
             <link>https://blog.beraliv.dev/2021-04-13-unwrapping-promises</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-13-unwrapping-promises</guid>
@@ -301,7 +301,7 @@
             <pubDate>Tue, 13 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Exclude under the hood]]></title>
+            <title><![CDATA[Exclude type under the hood in TypeScript]]></title>
             <description><![CDATA[Given two unions, remove all the elements of the second one from the first union]]></description>
             <link>https://blog.beraliv.dev/2021-04-12-exclude-under-the-hood</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-12-exclude-under-the-hood</guid>
@@ -309,7 +309,7 @@
             <pubDate>Mon, 12 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Infer length]]></title>
+            <title><![CDATA[Infer tuple length in TypeScript]]></title>
             <description><![CDATA[Given the tuple, return its length]]></description>
             <link>https://blog.beraliv.dev/2021-04-09-infer-length</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-09-infer-length</guid>
@@ -317,7 +317,7 @@
             <pubDate>Fri, 09 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Infer first element]]></title>
+            <title><![CDATA[Infer first element of tuple type in TypeScript]]></title>
             <description><![CDATA[Given the tuple, return its first element]]></description>
             <link>https://blog.beraliv.dev/2021-04-08-infer-first-element</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-08-infer-first-element</guid>
@@ -325,7 +325,7 @@
             <pubDate>Thu, 08 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Making object out of tuple]]></title>
+            <title><![CDATA[Transform tuple type into object type with same key and value in TypeScript]]></title>
             <description><![CDATA[Given the tuple, we need to get object where key and value equals to the elements of the tuple]]></description>
             <link>https://blog.beraliv.dev/2021-04-07-making-object-out-of-tuple</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-07-making-object-out-of-tuple</guid>
@@ -333,7 +333,7 @@
             <pubDate>Wed, 07 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Readonly under the hood]]></title>
+            <title><![CDATA[Readonly type under the hood in TypeScript]]></title>
             <description><![CDATA[Given the object, we need to make properties on the first level readonly]]></description>
             <link>https://blog.beraliv.dev/2021-04-06-readonly-under-the-hood</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-06-readonly-under-the-hood</guid>
@@ -341,7 +341,7 @@
             <pubDate>Tue, 06 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Pick under the hood]]></title>
+            <title><![CDATA[Pick type under the hood in TypeScript]]></title>
             <description><![CDATA[Given existing type or interface, we need to extract part of properties]]></description>
             <link>https://blog.beraliv.dev/2021-04-05-pick-under-the-hood</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-05-pick-under-the-hood</guid>
@@ -349,7 +349,7 @@
             <pubDate>Mon, 05 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Type Challenges]]></title>
+            <title><![CDATA[List of Type Challenges problems and solutions]]></title>
             <description><![CDATA[Easy, medium, hard and extreme step by step solutions to type challenges in TypeScript]]></description>
             <link>https://blog.beraliv.dev/2021-04-04-type-challenges</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-04-04-type-challenges</guid>
@@ -357,7 +357,7 @@
             <pubDate>Sun, 04 Apr 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Advanced Get]]></title>
+            <title><![CDATA[Type-safe get function that extracts the value by paths in TypeScript]]></title>
             <description><![CDATA[Basic implementation of getting a value in an object, optional paths, array and tuples, one solution with connection to JavaScript]]></description>
             <link>https://blog.beraliv.dev/2021-03-26-typed-get</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2021-03-26-typed-get</guid>
@@ -365,7 +365,7 @@
             <pubDate>Fri, 26 Mar 2021 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Video ads player in Yandex]]></title>
+            <title><![CDATA[Working in Video Advertising player at Yandex]]></title>
             <description><![CDATA[Developed features, team members and collaboration inside the team]]></description>
             <link>https://blog.beraliv.dev/2020-10-06-work-in-video-advertising-player-in-yandex</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2020-10-06-work-in-video-advertising-player-in-yandex</guid>
@@ -373,7 +373,7 @@
             <pubDate>Tue, 06 Oct 2020 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Video player in Joyn]]></title>
+            <title><![CDATA[Code obfuscation in Joyn video player (2020 edition)]]></title>
             <description><![CDATA[Code obfuscation using confusion and the way how to make it readable again]]></description>
             <link>https://blog.beraliv.dev/2020-05-04-research-joyn-scripts-obfuscation</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2020-05-04-research-joyn-scripts-obfuscation</guid>
@@ -381,7 +381,7 @@
             <pubDate>Mon, 04 May 2020 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Video player in Udemy]]></title>
+            <title><![CDATA[Subtitles, statistics and DRM in Udemy video player (2020 edition)]]></title>
             <description><![CDATA[Subtitles with WebVTT, statistics and DRM]]></description>
             <link>https://blog.beraliv.dev/2020-01-07-whats-inside-udemy-player</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2020-01-07-whats-inside-udemy-player</guid>
@@ -389,7 +389,7 @@
             <pubDate>Tue, 07 Jan 2020 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Video player in BBC]]></title>
+            <title><![CDATA[Geolocation identification in BBC iPlayer (2019 edition)]]></title>
             <description><![CDATA[Geolocation identification in iPlayer]]></description>
             <link>https://blog.beraliv.dev/2019-12-22-bbc-iplayer-geolocation-identification</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2019-12-22-bbc-iplayer-geolocation-identification</guid>
@@ -397,7 +397,7 @@
             <pubDate>Sun, 22 Dec 2019 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Video player in Amazon]]></title>
+            <title><![CDATA[State machine and bundles in Amazon video player (2019 edition)]]></title>
             <description><![CDATA[From video tag to the implementation, state machine, the way bundle is loaded, bundle names]]></description>
             <link>https://blog.beraliv.dev/2019-12-17-amazon-prime-video-player-investigation</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2019-12-17-amazon-prime-video-player-investigation</guid>
@@ -405,7 +405,7 @@
             <pubDate>Tue, 17 Dec 2019 00:00:00 GMT</pubDate>
         </item>
         <item>
-            <title><![CDATA[Scrollbar customisation]]></title>
+            <title><![CDATA[Scrollbar customisation in CSS and JS]]></title>
             <description><![CDATA[CSS support in different browser engines, hacks and tricks, JS libraries]]></description>
             <link>https://blog.beraliv.dev/2018-10-04-scrollbar-customisation</link>
             <guid isPermaLink="false">https://blog.beraliv.dev/2018-10-04-scrollbar-customisation</guid>

--- a/packages/blog2/src/components/atoms/DarkModeToggle/index.module.css
+++ b/packages/blog2/src/components/atoms/DarkModeToggle/index.module.css
@@ -8,15 +8,22 @@
   border-radius: 9999px;
   cursor: pointer;
   color: var(--dark-mode-toggle-color);
-  background-color: var(--dark-mode-toggle-background-color);
 
-  transform: scale(1);
-  transition: all 0.2s ease-in-out;
+  /* hide until dark mode is initialised */
+  visibility: hidden;
 }
 
 .toggle:hover {
   outline: none;
   transform: scale(1.25);
+}
+
+.sun,
+.moon {
+  visibility: visible;
+
+  transform: scale(1);
+  transition: all 0.2s ease-in-out;
 }
 
 .sun {

--- a/packages/blog2/src/components/atoms/DarkModeToggle/index.module.css
+++ b/packages/blog2/src/components/atoms/DarkModeToggle/index.module.css
@@ -14,9 +14,20 @@
   transition: all 0.2s ease-in-out;
 }
 
-.toggle:hover,
-.toggle:active,
-.toggle:focus {
+.toggle:hover {
   outline: none;
   transform: scale(1.25);
+}
+
+.sun {
+  --dark-yellow: #f6d602;
+  --light-yellow: #f5eb71;
+
+  transform: scale(1.2);
+  background-color: var(--dark-yellow);
+  border: 5px solid var(--light-yellow);
+}
+
+.moon {
+  box-shadow: 0 0 35px 5px white, 0 0 25px 10px white inset;
 }

--- a/packages/blog2/src/components/atoms/DarkModeToggle/index.tsx
+++ b/packages/blog2/src/components/atoms/DarkModeToggle/index.tsx
@@ -1,16 +1,18 @@
 import React from "react";
 import { useDarkMode } from "../../../hooks/useDarkMode";
 import styles from "./index.module.css";
+import { classNames } from "../../../functions/classNames";
 
 export const DarkModeToggle = () => {
   const { darkMode, toggle } = useDarkMode();
 
   return (
-    <input
-      className={styles.toggle}
-      type="button"
-      value={darkMode ? "☀" : "☾"}
+    <div
+      className={classNames(styles.toggle, {
+        [styles.moon]: darkMode,
+        [styles.sun]: !darkMode,
+      })}
       onClick={toggle}
-    />
+    ></div>
   );
 };

--- a/packages/blog2/src/components/atoms/DarkModeToggle/index.tsx
+++ b/packages/blog2/src/components/atoms/DarkModeToggle/index.tsx
@@ -4,13 +4,13 @@ import styles from "./index.module.css";
 import { classNames } from "../../../functions/classNames";
 
 export const DarkModeToggle = () => {
-  const { darkMode, toggle } = useDarkMode();
+  const { darkMode, initialising, toggle } = useDarkMode();
 
   return (
     <div
       className={classNames(styles.toggle, {
-        [styles.moon]: darkMode,
-        [styles.sun]: !darkMode,
+        [styles.moon]: darkMode && !initialising,
+        [styles.sun]: !darkMode && !initialising,
       })}
       onClick={toggle}
     ></div>

--- a/packages/blog2/src/components/molecules/PostPreview/index.module.css
+++ b/packages/blog2/src/components/molecules/PostPreview/index.module.css
@@ -1,63 +1,20 @@
-.card {
-  margin: 1rem;
-  padding: 1.5rem;
-  text-align: left;
-  color: inherit;
-  text-decoration: none;
-  border: 1px solid var(--border-color);
-  border-radius: 0.25rem;
-  transition: color 0.15s ease, border-color 0.15s ease;
-  width: 30rem;
-}
-
-/*
-    min-width + .card width doesn't work the same way here
-    as we need to set maximum width to 42rem
-  */
-@media (max-width: 42rem) {
-  .card {
-    width: 100%;
-  }
-}
-
-.card:hover,
-.card:focus,
-.card:active {
-  outline: none;
-  color: var(--focus-color);
-  border-color: var(--focus-color);
-}
-
-.card pre {
-  height: 1.5rem;
-  margin: 0 0 0.5rem;
-}
-
-.card h2 {
-  --header-size: 1.5rem;
-  --header-line-height: 1.5;
-
-  margin: 0 0 1rem 0;
-  font-size: var(--header-size);
-  height: calc(2 * var(--header-size) * var(--header-line-height));
-
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.card p {
-  --text-size: 1rem;
-  --text-line-height: 1.5;
-
+.row,
+.row td {
   margin: 0;
-  font-size: var(--text-size);
-  line-height: var(--text-line-height);
-  height: calc(3 * var(--text-size) * var(--text-line-height));
+  border: 0;
+}
 
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+.row td.date,
+.row td.title {
+  vertical-align: baseline;
+}
+
+.date,
+.labels {
+  white-space: nowrap;
+  padding-right: 0.5rem;
+}
+
+.labels {
+  display: inline-block;
 }

--- a/packages/blog2/src/components/molecules/PostPreview/index.tsx
+++ b/packages/blog2/src/components/molecules/PostPreview/index.tsx
@@ -1,29 +1,16 @@
 import { Fragment } from "react";
-import { PostType } from "../../../types/PostType";
-import { SanitisedString } from "../../../types/SanitisedString";
 import { labelToIconMapping } from "../labelToIconMapping";
 import styles from "./index.module.css";
+import { ValidatedPostType } from "../../../types/ValidatedPostType";
 
-type PostPreviewPropsType = Pick<
-  PostType,
-  "slug" | "description" | "labels"
-> & {
-  title: SanitisedString;
-};
-
-export const PostPreview = ({
-  description,
-  labels,
-  slug,
-  title,
-}: PostPreviewPropsType) => (
-  <a href={slug} key={slug} className={styles.card}>
-    <pre>
-      {labels.map((label) => (
+export const PostPreview = (post: ValidatedPostType) => (
+  <a href={post.slug} className={styles.card}>
+    <pre className={styles.labels}>
+      {post.labels.map((label) => (
         <Fragment key={label}>{labelToIconMapping[label]}</Fragment>
       ))}
     </pre>
-    <h2>{title}</h2>
-    <p>{description}</p>
+    <h2>{post.title}</h2>
+    <p>{post.description}</p>
   </a>
 );

--- a/packages/blog2/src/components/molecules/PostPreview/index.tsx
+++ b/packages/blog2/src/components/molecules/PostPreview/index.tsx
@@ -4,13 +4,17 @@ import styles from "./index.module.css";
 import { ValidatedPostType } from "../../../types/ValidatedPostType";
 
 export const PostPreview = (post: ValidatedPostType) => (
-  <a href={post.slug} className={styles.card}>
-    <pre className={styles.labels}>
-      {post.labels.map((label) => (
+  <tr className={styles.row}>
+    <td className={styles.date}>{post.date}</td>
+    <td className={styles.labels}>
+      {[post.labels[0]].map((label) => (
         <Fragment key={label}>{labelToIconMapping[label]}</Fragment>
       ))}
-    </pre>
-    <h2>{post.title}</h2>
-    <p>{post.description}</p>
-  </a>
+    </td>
+    <td className={styles.title}>
+      <a href={post.slug}>
+        <span>{post.title}</span>
+      </a>
+    </td>
+  </tr>
 );

--- a/packages/blog2/src/components/pages/Home/index.module.css
+++ b/packages/blog2/src/components/pages/Home/index.module.css
@@ -1,18 +1,11 @@
 .container {
+  margin: 0 auto;
+  max-width: 42rem;
   padding: 1rem 1.25rem;
-}
-
-.main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
 }
 
 .bio,
 .aside {
-  max-width: 42rem;
   margin: 0 auto;
 }
 
@@ -20,11 +13,10 @@
   padding: 2.5rem 1.25rem;
 }
 
-.grid {
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  flex-wrap: wrap;
+.table {
+  border: 0;
+  padding: 0;
+  margin: 0;
 }
 
 .goToSearch {

--- a/packages/blog2/src/components/pages/Home/index.tsx
+++ b/packages/blog2/src/components/pages/Home/index.tsx
@@ -10,7 +10,6 @@ import { Header } from "../../molecules/Header";
 import { Seo } from "../../molecules/Seo";
 import { SubscriptionForm } from "../../molecules/SubscriptionForm";
 import styles from "./index.module.css";
-import { sanitiseHtml } from "../../../functions/sanitiseHtml";
 import { SanitisedString } from "../../../types/SanitisedString";
 import { PROMO_IMAGE } from "../../../constants/PROMO_IMAGE";
 
@@ -43,27 +42,15 @@ export const Home = ({
 
         <h3>Featured</h3>
         <div className={styles.grid}>
-          {featuredPosts.map(({ description, labels, slug, title }) => (
-            <PostPreview
-              key={slug}
-              description={description}
-              labels={labels}
-              slug={slug}
-              title={sanitiseHtml(title)}
-            />
+          {featuredPosts.map((post) => (
+            <PostPreview key={post.slug} {...post} />
           ))}
         </div>
 
         <h3>Latest</h3>
         <div className={styles.grid}>
-          {latestPosts.map(({ description, labels, slug, title }) => (
-            <PostPreview
-              key={slug}
-              description={description}
-              labels={labels}
-              slug={slug}
-              title={sanitiseHtml(title)}
-            />
+          {latestPosts.map((post) => (
+            <PostPreview key={post.slug} {...post} />
           ))}
         </div>
 

--- a/packages/blog2/src/components/pages/Home/index.tsx
+++ b/packages/blog2/src/components/pages/Home/index.tsx
@@ -19,7 +19,7 @@ export const Home = ({
   apiKey,
   formId,
   featuredPosts,
-  latestPosts,
+  mostRecent10Posts,
 }: InferGetStaticPropsType<typeof getHomeStaticProps>) => {
   const { author, keywords, title, url } = BLOG_META_INFO;
 
@@ -35,33 +35,35 @@ export const Home = ({
 
       <Header title={title} path="home" />
 
-      <main className={styles.main}>
-        <div className={styles.bio}>
-          <Bio />
-        </div>
+      <div className={styles.bio}>
+        <Bio />
+      </div>
 
-        <h3>Featured</h3>
-        <div className={styles.grid}>
+      <h3>⭐️ Featured</h3>
+      <table className={styles.table}>
+        <tbody>
           {featuredPosts.map((post) => (
             <PostPreview key={post.slug} {...post} />
           ))}
-        </div>
+        </tbody>
+      </table>
 
-        <h3>Latest</h3>
-        <div className={styles.grid}>
-          {latestPosts.map((post) => (
+      <h3>🕞 Most recent 10 posts</h3>
+      <table className={styles.table}>
+        <tbody>
+          {mostRecent10Posts.map((post) => (
             <PostPreview key={post.slug} {...post} />
           ))}
-        </div>
+        </tbody>
+      </table>
 
-        <div className={styles.goToSearch}>
-          <NextLink href="/search">🔎 See all articles</NextLink>
-        </div>
+      <div className={styles.goToSearch}>
+        <NextLink href="/search">🔎 See all articles</NextLink>
+      </div>
 
-        <aside className={styles.aside}>
-          <SubscriptionForm apiKey={apiKey} formId={formId} />
-        </aside>
-      </main>
+      <aside className={styles.aside}>
+        <SubscriptionForm apiKey={apiKey} formId={formId} />
+      </aside>
 
       <Footer />
     </div>

--- a/packages/blog2/src/components/pages/Post/index.tsx
+++ b/packages/blog2/src/components/pages/Post/index.tsx
@@ -24,7 +24,13 @@ export interface PostPropsType {
     StrictOmit<
       MarkRequired<
         Partial<PostType>,
-        "date" | "description" | "keywords" | "labels" | "slug" | "title"
+        | "rawDate"
+        | "date"
+        | "description"
+        | "keywords"
+        | "labels"
+        | "slug"
+        | "title"
       >,
       "title"
     > & { title: SanitisedString },

--- a/packages/blog2/src/components/pages/Post/index.tsx
+++ b/packages/blog2/src/components/pages/Post/index.tsx
@@ -11,20 +11,23 @@ import { Header } from "../../molecules/Header";
 import { Seo } from "../../molecules/Seo";
 import { BLOG_META_INFO } from "../../../constants/BLOG_META_INFO";
 import { SubscriptionForm } from "../../molecules/SubscriptionForm";
-import { sanitiseHtml } from "../../../functions/sanitiseHtml";
 import { ArticleMainProgress } from "../../atoms/ArticleMainProgress";
 import { useEffect } from "react";
 import type { MarkRequired } from "ts-essentials";
+import { SanitisedString } from "../../../types/SanitisedString";
 
 export interface PostPropsType {
   apiKey: string;
   content: Awaited<ReturnType<typeof serialize>>;
   formId: string;
   post: StrictOmit<
-    MarkRequired<
-      Partial<PostType>,
-      "date" | "description" | "keywords" | "labels" | "slug" | "title"
-    >,
+    StrictOmit<
+      MarkRequired<
+        Partial<PostType>,
+        "date" | "description" | "keywords" | "labels" | "slug" | "title"
+      >,
+      "title"
+    > & { title: SanitisedString },
     "image"
   >;
   image: ImageType;
@@ -52,7 +55,7 @@ export const Post = ({
         image={image}
         keywords={post.keywords}
         path={`${baseUrl}${post.slug}`}
-        title={sanitiseHtml(post.title)}
+        title={post.title}
       />
 
       <ArticleMainProgress />

--- a/packages/blog2/src/components/pages/Search/index.module.css
+++ b/packages/blog2/src/components/pages/Search/index.module.css
@@ -1,4 +1,6 @@
 .container {
+  max-width: 42rem;
+  margin: 0 auto;
   padding: 1rem 1.25rem;
 }
 
@@ -8,12 +10,6 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-}
-
-.bio,
-.aside {
-  max-width: 42rem;
-  margin: 0 auto;
 }
 
 .bio {
@@ -65,9 +61,8 @@
   }
 }
 
-.grid {
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  flex-wrap: wrap;
+.table {
+  margin: 0;
+  padding: 0;
+  border: 0;
 }

--- a/packages/blog2/src/components/pages/Search/index.tsx
+++ b/packages/blog2/src/components/pages/Search/index.tsx
@@ -45,7 +45,7 @@ export const Search = ({
 
           return true;
         })();
-        const byTitle = sanitiseHtml(post.title).toLowerCase().includes(search);
+        const byTitle = post.title.toLowerCase().includes(search);
         const byDescription = post.description.toLowerCase().includes(search);
 
         return byLabel && (byTitle || byDescription);
@@ -117,14 +117,8 @@ export const Search = ({
         </div>
 
         <div className={styles.grid}>
-          {filteredPosts.map(({ description, labels, slug, title }) => (
-            <PostPreview
-              key={slug}
-              description={description}
-              labels={labels}
-              slug={slug}
-              title={sanitiseHtml(title)}
-            />
+          {filteredPosts.map((post) => (
+            <PostPreview key={post.slug} {...post} />
           ))}
         </div>
 

--- a/packages/blog2/src/components/pages/Search/index.tsx
+++ b/packages/blog2/src/components/pages/Search/index.tsx
@@ -116,11 +116,13 @@ export const Search = ({
           <div className={styles.searchElements}>{filteredPosts.length}</div>
         </div>
 
-        <div className={styles.grid}>
-          {filteredPosts.map((post) => (
-            <PostPreview key={post.slug} {...post} />
-          ))}
-        </div>
+        <table className={styles.table}>
+          <tbody>
+            {filteredPosts.map((post) => (
+              <PostPreview key={post.slug} {...post} />
+            ))}
+          </tbody>
+        </table>
 
         <aside className={styles.aside}>
           <SubscriptionForm apiKey={apiKey} formId={formId} />

--- a/packages/blog2/src/content/2018-10-04-scrollbar-customisation.md
+++ b/packages/blog2/src/content/2018-10-04-scrollbar-customisation.md
@@ -1,5 +1,5 @@
 ---
-title: Scrollbar cus&shy;tomi&shy;sa&shy;tion
+title: Scrollbar cus&shy;tomi&shy;sa&shy;tion in CSS and JS
 date: "2018-10-04"
 description: CSS support in different browser engines, hacks and tricks, JS libraries
 labels:

--- a/packages/blog2/src/content/2019-12-17-amazon-prime-video-player-investigation.md
+++ b/packages/blog2/src/content/2019-12-17-amazon-prime-video-player-investigation.md
@@ -1,5 +1,5 @@
 ---
-title: Video player in Amazon
+title: State machine and bundles in Amazon video player (2019 edition)
 date: "2019-12-17"
 description: From video tag to the implementation, state machine, the way bundle is loaded, bundle names
 labels:

--- a/packages/blog2/src/content/2019-12-22-bbc-iplayer-geolocation-identification.md
+++ b/packages/blog2/src/content/2019-12-22-bbc-iplayer-geolocation-identification.md
@@ -1,5 +1,5 @@
 ---
-title: Video player in BBC
+title: Geolocation identification in BBC iPlayer (2019 edition)
 date: "2019-12-22"
 description: Geolocation identification in iPlayer
 labels:

--- a/packages/blog2/src/content/2020-01-07-whats-inside-udemy-player.md
+++ b/packages/blog2/src/content/2020-01-07-whats-inside-udemy-player.md
@@ -1,5 +1,5 @@
 ---
-title: Video player in Udemy
+title: Subtitles, statistics and DRM in Udemy video player (2020 edition)
 date: "2020-01-07"
 description: Subtitles with WebVTT, statistics and DRM
 labels:

--- a/packages/blog2/src/content/2020-05-04-research-joyn-scripts-obfuscation.md
+++ b/packages/blog2/src/content/2020-05-04-research-joyn-scripts-obfuscation.md
@@ -1,5 +1,5 @@
 ---
-title: Video player in Joyn
+title: Code obfuscation in Joyn video player (2020 edition)
 date: "2020-05-04"
 description: Code obfuscation using confusion and the way how to make it readable again
 labels:

--- a/packages/blog2/src/content/2020-10-06-work-in-video-advertising-player-in-yandex.md
+++ b/packages/blog2/src/content/2020-10-06-work-in-video-advertising-player-in-yandex.md
@@ -1,5 +1,5 @@
 ---
-title: Video ads player in Yandex
+title: Working in Video Advertising player at Yandex
 date: "2020-10-06"
 description: Developed features, team members and collaboration inside the team
 labels:
@@ -14,7 +14,7 @@ image: /work-in-video-advertising-player-in-yandex/yandex-overlay-in-player.png
 
 ![Yandex overlay in player](/work-in-video-advertising-player-in-yandex/yandex-overlay-in-player.png)
 
-Hey! My name is Alex, and I've spent around 2 years in Yandex, in video player and [video advertising](https://yandex.com/adv/products/video) teams for more than a year in each one.
+Hey! My name is Alexey, and I've spent around 2 years in Yandex, in video player and [video advertising](https://yandex.com/adv/products/video) teams for more than a year in each one.
 
 As the last year is fresh in my memory, I would like to share my experience in video advertising.
 

--- a/packages/blog2/src/content/2021-03-26-typed-get.md
+++ b/packages/blog2/src/content/2021-03-26-typed-get.md
@@ -1,5 +1,5 @@
 ---
-title: Advanced Get
+title: Type-safe get function that extracts the value by paths in TypeScript
 date: "2021-03-26"
 description: Basic implementation of getting a value in an object, optional paths, array and tuples, one solution with connection to JavaScript
 labels:

--- a/packages/blog2/src/content/2021-04-04-type-challenges.md
+++ b/packages/blog2/src/content/2021-04-04-type-challenges.md
@@ -1,5 +1,5 @@
 ---
-title: Type Challenges
+title: List of Type Challenges problems and solutions
 date: "2021-04-04"
 description: Easy, medium, hard and extreme step by step solutions to type challenges in TypeScript
 labels:

--- a/packages/blog2/src/content/2021-04-04-type-challenges.md
+++ b/packages/blog2/src/content/2021-04-04-type-challenges.md
@@ -58,7 +58,7 @@ I take the challenges from [type-challenges](https://github.com/type-challenges/
 - String to Union • [Challenge](https://github.com/type-challenges/type-challenges/blob/master/questions/00531-medium-string-to-union/README.md) • [Solution](/2021/06/19/making-union-out-of-string/)
 - Merge • [Challenge](https://github.com/type-challenges/type-challenges/blob/master/questions/00599-medium-merge/README.md) • [Solution](/2021/07/05/spread-in-typescript/)
 
-Will add more solutions at January, 2021
+To be added...
 
 ## hard
 
@@ -69,8 +69,4 @@ Will add more solutions at January, 2021
 - Split • [Challenge](https://github.com/type-challenges/type-challenges/blob/master/questions/02822-hard-split/README.md) – [Solution](/2021-11-29-split/)
 - CamelCase • [Challenge](https://github.com/type-challenges/type-challenges/blob/main/questions/00114-hard-camelcase/README.md) – [Solution](/2022-07-14-camel-case/)
 
-Will add more solutions at January, 2021
-
-## extreme
-
-Will add more solutions at January, 2021
+To be added...

--- a/packages/blog2/src/content/2021-04-05-pick-under-the-hood.md
+++ b/packages/blog2/src/content/2021-04-05-pick-under-the-hood.md
@@ -1,5 +1,5 @@
 ---
-title: Pick under the hood
+title: Pick type under the hood in TypeScript
 date: "2021-04-05"
 description: Given existing type or interface, we need to extract part of properties
 labels:

--- a/packages/blog2/src/content/2021-04-06-readonly-under-the-hood.md
+++ b/packages/blog2/src/content/2021-04-06-readonly-under-the-hood.md
@@ -1,5 +1,5 @@
 ---
-title: Readonly under the hood
+title: Readonly type under the hood in TypeScript
 date: "2021-04-06"
 description: Given the object, we need to make properties on the first level readonly
 labels:

--- a/packages/blog2/src/content/2021-04-07-making-object-out-of-tuple.md
+++ b/packages/blog2/src/content/2021-04-07-making-object-out-of-tuple.md
@@ -1,5 +1,5 @@
 ---
-title: Making object out of tuple
+title: Transform tuple type into object type with same key and value in TypeScript
 date: "2021-04-07"
 description: Given the tuple, we need to get object where key and value equals to the elements of the tuple
 labels:

--- a/packages/blog2/src/content/2021-04-08-infer-first-element.md
+++ b/packages/blog2/src/content/2021-04-08-infer-first-element.md
@@ -1,5 +1,5 @@
 ---
-title: Infer first element
+title: Infer first element of tuple type in TypeScript
 date: "2021-04-08"
 description: Given the tuple, return its first element
 labels:

--- a/packages/blog2/src/content/2021-04-09-infer-length.md
+++ b/packages/blog2/src/content/2021-04-09-infer-length.md
@@ -1,5 +1,5 @@
 ---
-title: Infer length
+title: Infer tuple length in TypeScript
 date: "2021-04-09"
 description: Given the tuple, return its length
 labels:

--- a/packages/blog2/src/content/2021-04-12-exclude-under-the-hood.md
+++ b/packages/blog2/src/content/2021-04-12-exclude-under-the-hood.md
@@ -1,5 +1,5 @@
 ---
-title: Exclude under the hood
+title: Exclude type under the hood in TypeScript
 date: "2021-04-12"
 description: Given two unions, remove all the elements of the second one from the first union
 labels:

--- a/packages/blog2/src/content/2021-04-13-unwrapping-promises.md
+++ b/packages/blog2/src/content/2021-04-13-unwrapping-promises.md
@@ -1,5 +1,5 @@
 ---
-title: Unwrapping Promises
+title: Awaited type under the hood in TypeScript
 date: "2021-04-13"
 description: Given the promise, return the value after applying await recursively
 labels:

--- a/packages/blog2/src/content/2021-04-14-boolean-condition.md
+++ b/packages/blog2/src/content/2021-04-14-boolean-condition.md
@@ -1,5 +1,5 @@
 ---
-title: Boolean conditional statement
+title: If statement type in TypeScript
 date: "2021-04-14"
 description: Given the boolean, in case of true return first type, otherwise second one
 labels:

--- a/packages/blog2/src/content/2021-04-15-spread-in-tuple-types-in-typescript.md
+++ b/packages/blog2/src/content/2021-04-15-spread-in-tuple-types-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Spread in Tuple types
+title: TypeScript spread operator for 2 tuple types
 date: "2021-04-15"
 description: Given two tuples, put the elements of both of them into the resulting tuple
 labels:

--- a/packages/blog2/src/content/2021-04-16-includes-in-typescript.md
+++ b/packages/blog2/src/content/2021-04-16-includes-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Includes
+title: Includes type in TypeScript
 date: "2021-04-16"
 description: Given the tuple and the type, return true if the type is an element of the tuple. Otherwise, return false
 labels:

--- a/packages/blog2/src/content/2021-04-19-return-type-under-the-hood.md
+++ b/packages/blog2/src/content/2021-04-19-return-type-under-the-hood.md
@@ -1,5 +1,5 @@
 ---
-title: ReturnType under the hood
+title: ReturnType under the hood in TypeScript
 date: "2021-04-19"
 description: Given the function, we need to extract what it returns
 labels:

--- a/packages/blog2/src/content/2021-04-21-omit-under-the-hood.md
+++ b/packages/blog2/src/content/2021-04-21-omit-under-the-hood.md
@@ -1,5 +1,5 @@
 ---
-title: Omit under the hood
+title: Omit type under the hood in TypeScript
 date: "2021-04-21"
 description: Given the object and a union of properties, return the object but without those properties
 labels:

--- a/packages/blog2/src/content/2021-04-23-partial-readonly.md
+++ b/packages/blog2/src/content/2021-04-23-partial-readonly.md
@@ -1,5 +1,5 @@
 ---
-title: Partial Readonly
+title: Conditionally readonly object type in TypeScript
 date: "2021-04-23"
 description: Given the object and a union of properties, return object where those properties are readonly
 labels:

--- a/packages/blog2/src/content/2021-04-25-recursive-readonly-for-objects.md
+++ b/packages/blog2/src/content/2021-04-25-recursive-readonly-for-objects.md
@@ -1,5 +1,5 @@
 ---
-title: Recursive Readonly for objects
+title: Recursive readonly object type in TypeScript
 date: "2021-04-25"
 description: Given the object, return object where all properties on all levels are readonly
 labels:

--- a/packages/blog2/src/content/2021-04-27-making-union-out-of-tuple.md
+++ b/packages/blog2/src/content/2021-04-27-making-union-out-of-tuple.md
@@ -1,5 +1,5 @@
 ---
-title: Making union out of tuple
+title: Transform tuple type into a union in TypeScript
 date: "2021-04-27"
 description: Given the tuple, return a union of tuple elements
 labels:

--- a/packages/blog2/src/content/2021-04-28-chainable-options.md
+++ b/packages/blog2/src/content/2021-04-28-chainable-options.md
@@ -1,5 +1,5 @@
 ---
-title: Chainable Options
+title: Chainable options type in TypeScript
 date: "2021-04-28"
 description: Given API, collect the object with keys and values after each call
 labels:

--- a/packages/blog2/src/content/2021-04-29-infer-last-element.md
+++ b/packages/blog2/src/content/2021-04-29-infer-last-element.md
@@ -1,5 +1,5 @@
 ---
-title: Infer last element
+title: Infer last element of tuple type in TypeScript
 date: "2021-04-29"
 description: Given the tuple, return its last element
 labels:

--- a/packages/blog2/src/content/2021-05-01-manipulation-with-tuple-elements.md
+++ b/packages/blog2/src/content/2021-05-01-manipulation-with-tuple-elements.md
@@ -1,5 +1,5 @@
 ---
-title: Manipulation with Tuple elements
+title: Manipulation with elements of tuple type in TypeScript
 date: "2021-05-01"
 description: Given the tuple, implement Pop, Shift, Push and Unshift methods like Array.prototype has
 labels:

--- a/packages/blog2/src/content/2021-05-04-promise-all-under-the-hood.md
+++ b/packages/blog2/src/content/2021-05-04-promise-all-under-the-hood.md
@@ -1,5 +1,5 @@
 ---
-title: Promise.all under the hood
+title: Promise.all types under the hood in TypeScript
 date: "2021-05-04"
 description: Given the tuple with Promise elements, return Promise of tuple
 labels:

--- a/packages/blog2/src/content/2021-05-06-extract-under-the-hood.md
+++ b/packages/blog2/src/content/2021-05-06-extract-under-the-hood.md
@@ -1,5 +1,5 @@
 ---
-title: Extract under the hood
+title: Extract under the hood in TypeScript
 date: "2021-05-06"
 description: Given a union of several types, remove those types which doesn't extend the specified structure
 labels:

--- a/packages/blog2/src/content/2021-05-07-opaque-type-in-typescript.md
+++ b/packages/blog2/src/content/2021-05-07-opaque-type-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Opaque Types
+title: Opaque Types in TypeScript
 date: "2021-05-07"
 description: Structural type system, workaround in TypeScript, unique symbol and code examples
 labels:

--- a/packages/blog2/src/content/2021-05-10-trim-left-in-typescript.md
+++ b/packages/blog2/src/content/2021-05-10-trim-left-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Trim Left
+title: Trim left part of string literal type in TypeScript
 date: "2021-05-10"
 description: Given the string, remove whitespaces from the beginning
 labels:

--- a/packages/blog2/src/content/2021-05-11-trim-in-typescript.md
+++ b/packages/blog2/src/content/2021-05-11-trim-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Trim
+title: Trim string literal type in TypeScript
 date: "2021-05-11"
 description: Given the string, remove whitespaces from the beginning and the end
 labels:

--- a/packages/blog2/src/content/2021-05-14-type-aliases-for-string-manipulation.md
+++ b/packages/blog2/src/content/2021-05-14-type-aliases-for-string-manipulation.md
@@ -1,5 +1,5 @@
 ---
-title: Type Aliases for String manipulation
+title: Intrinsic string manipulation types in TypeScript
 date: "2021-05-14"
 description: Uppercase, Lowercase, Capitalize and Uncapitalize since TypeScript 4.1
 labels:

--- a/packages/blog2/src/content/2021-05-17-replace-occurrence-in-a-string-in-typescript.md
+++ b/packages/blog2/src/content/2021-05-17-replace-occurrence-in-a-string-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Replace occurrence in a string
+title: Replace occurrence in string literal type in TypeScript
 date: "2021-05-17"
 description: Given the string, replace first string occurrence with specified string
 labels:

--- a/packages/blog2/src/content/2021-05-22-replace-all-occurrences-in-a-string-in-typescript.md
+++ b/packages/blog2/src/content/2021-05-22-replace-all-occurrences-in-a-string-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Replace all occurrences in a string
+title: Replace all occurrences in string literal type in TypeScript
 date: "2021-05-22"
 description: Given the string, replace all string occurrences with specified string
 labels:

--- a/packages/blog2/src/content/2021-05-23-append-argument.md
+++ b/packages/blog2/src/content/2021-05-23-append-argument.md
@@ -1,5 +1,5 @@
 ---
-title: Append argument to a function
+title: Append argument type into function type in TypeScript
 date: "2021-05-23"
 description: Given the function and the type, include the type as the following argument in the list of function arguments
 labels:

--- a/packages/blog2/src/content/2021-05-30-permutations-in-typescript.md
+++ b/packages/blog2/src/content/2021-05-30-permutations-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Permutations
+title: Calculate all permutations of union type in TypeScript
 date: "2021-05-30"
 description: Given a union, return a union of tuples with all possible permutations (all possible positions of elements without repetition)
 labels:

--- a/packages/blog2/src/content/2021-05-31-string-length-in-typescript.md
+++ b/packages/blog2/src/content/2021-05-31-string-length-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Length of String
+title: Infer string length in TypeScript
 date: "2021-05-31"
 description: Given the string, calculate its length. Also try to find the maximum computable string length having a limit of recursive calls
 labels:

--- a/packages/blog2/src/content/2021-06-13-flatten-tuple-type-in-typescript.md
+++ b/packages/blog2/src/content/2021-06-13-flatten-tuple-type-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Flatten Tuple Type
+title: Flatten tuple type of tuples in TypeScript
 date: "2021-06-13"
 description: Given the tuple, make it flatten as Array.prototype.flat when pass Infinity
 labels:

--- a/packages/blog2/src/content/2021-06-16-append-to-object.md
+++ b/packages/blog2/src/content/2021-06-16-append-to-object.md
@@ -1,5 +1,5 @@
 ---
-title: Append to Object
+title: Append key-value pair to object type in TypeScript
 date: "2021-06-16"
 description: We have spread on objects in JavaScript so we can add value by the specified key, let's find out how to do that in TypeScript.
 labels:

--- a/packages/blog2/src/content/2021-06-19-making-union-out-of-string.md
+++ b/packages/blog2/src/content/2021-06-19-making-union-out-of-string.md
@@ -1,5 +1,5 @@
 ---
-title: Making Union out of string
+title: Transform string literal type into union of characters in TypeScript
 date: "2021-06-19"
 description: Given a string, return a union of all characters from the string
 labels:

--- a/packages/blog2/src/content/2021-06-21-absolute-in-typescript.md
+++ b/packages/blog2/src/content/2021-06-21-absolute-in-typescript.md
@@ -1,5 +1,5 @@
 ---
-title: Absolute
+title: Math.abs for string literal type in TypeScript
 date: "2021-06-21"
 description: Given a number as a string, return its absolute value as a string too
 labels:

--- a/packages/blog2/src/content/2021-07-05-spread-in-typescript.md
+++ b/packages/blog2/src/content/2021-07-05-spread-in-typescript.md
@@ -1,7 +1,7 @@
 ---
-title: Spread in Object types
+title: TypeScript spread operator for 2 object types
 date: "2021-07-05"
-description: Given two objects, returns the object which is formed as a spread of two objects
+description: Given two objects, returns the object which is formed as a spread of two objects in TypeScript
 labels:
   - typescript
 keywords:

--- a/packages/blog2/src/content/2021-11-27-tuple-filter.md
+++ b/packages/blog2/src/content/2021-11-27-tuple-filter.md
@@ -1,5 +1,5 @@
 ---
-title: Tuple Filter
+title: Filter tuple type in TypeScript
 date: "2021-11-27"
 description: Given a tuple and a filter, returns the tuple without elements that are part of the filter
 labels:

--- a/packages/blog2/src/content/2021-11-29-split.md
+++ b/packages/blog2/src/content/2021-11-29-split.md
@@ -1,5 +1,5 @@
 ---
-title: Split
+title: Split string literal type in TypeScript
 date: "2021-11-29"
 description: Given a string and a separator, returns an array or a tuple with the substrings between the separator
 labels:

--- a/packages/blog2/src/content/2021-12-03-string-to-number.md
+++ b/packages/blog2/src/content/2021-12-03-string-to-number.md
@@ -1,5 +1,5 @@
 ---
-title: StringToNumber
+title: Convert string literal type into number literal type in TypeScript
 date: "2021-12-03"
 description: Given a number as string literal type, returns a number as number literal type
 labels:

--- a/packages/blog2/src/content/2021-12-07-get-optional.md
+++ b/packages/blog2/src/content/2021-12-07-get-optional.md
@@ -1,5 +1,5 @@
 ---
-title: GetOptional
+title: Extract object type with optional fields in TypeScript
 date: "2021-12-07"
 description: Given an object, returns object with all optional fields
 labels:

--- a/packages/blog2/src/content/2021-12-10-advanced-types-holyjs-notes.md
+++ b/packages/blog2/src/content/2021-12-10-advanced-types-holyjs-notes.md
@@ -1,5 +1,5 @@
 ---
-title: Advanced types / Holy.js notes
+title: Advanced types / Holy.js 2021 notes
 date: "2021-12-10"
 description: The power of TypeScript will be revealed by the example of several tasks from type-challenges of the hard level.
 labels:

--- a/packages/blog2/src/content/2022-07-14-camel-case.md
+++ b/packages/blog2/src/content/2022-07-14-camel-case.md
@@ -1,5 +1,5 @@
 ---
-title: CamelCase
+title: Transform string literal type into camelCase in TypeScript
 date: "2022-07-14"
 description: Given a string in any case, returns a string in camel case
 labels:

--- a/packages/blog2/src/functions/formatDate/index.test.ts
+++ b/packages/blog2/src/functions/formatDate/index.test.ts
@@ -1,0 +1,77 @@
+import { expect } from "earljs";
+import { formatDate } from ".";
+
+describe(formatDate.name, () => {
+  it("returns the string", () => {
+    expect(formatDate("1994-01-26", "test-slug")).toEqual("26 Jan 1994");
+  });
+
+  it("throws the error when month is lower than 1", () => {
+    expect(() => formatDate("2024-00-18", "test-slug")).toThrow(
+      'Cannot use month index -1 for slug "test-slug"'
+    );
+  });
+
+  it("throws the error when month is greater than 12", () => {
+    expect(() => formatDate("2024-13-18", "test-slug")).toThrow(
+      'Cannot use month index 12 for slug "test-slug"'
+    );
+  });
+
+  it("throws the error when day is lower than 1", () => {
+    expect(() => formatDate("2024-01-00", "test-slug")).toThrow(
+      'Cannot use day 0 for a month index 0 and slug "test-slug"'
+    );
+  });
+
+  it("throws the error when month is greater than the max for a specified month", () => {
+    // Jan
+    expect(() => formatDate("2024-01-32", "test-slug")).toThrow(
+      'Cannot use day 32 for a month index 0 and slug "test-slug"'
+    );
+    // Feb
+    expect(() => formatDate("2024-02-30", "test-slug")).toThrow(
+      'Cannot use day 30 for a month index 1 and slug "test-slug"'
+    );
+    //   Mar
+    expect(() => formatDate("2024-03-32", "test-slug")).toThrow(
+      'Cannot use day 32 for a month index 2 and slug "test-slug"'
+    );
+    //   Apr
+    expect(() => formatDate("2024-04-31", "test-slug")).toThrow(
+      'Cannot use day 31 for a month index 3 and slug "test-slug"'
+    );
+    //   May
+    expect(() => formatDate("2024-05-32", "test-slug")).toThrow(
+      'Cannot use day 32 for a month index 4 and slug "test-slug"'
+    );
+    //   Jun
+    expect(() => formatDate("2024-06-31", "test-slug")).toThrow(
+      'Cannot use day 31 for a month index 5 and slug "test-slug"'
+    );
+    //   Jul
+    expect(() => formatDate("2024-07-32", "test-slug")).toThrow(
+      'Cannot use day 32 for a month index 6 and slug "test-slug"'
+    );
+    //   Aug
+    expect(() => formatDate("2024-08-32", "test-slug")).toThrow(
+      'Cannot use day 32 for a month index 7 and slug "test-slug"'
+    );
+    //   Sep
+    expect(() => formatDate("2024-09-31", "test-slug")).toThrow(
+      'Cannot use day 31 for a month index 8 and slug "test-slug"'
+    );
+    //   Oct
+    expect(() => formatDate("2024-10-32", "test-slug")).toThrow(
+      'Cannot use day 32 for a month index 9 and slug "test-slug"'
+    );
+    //   Nov
+    expect(() => formatDate("2024-11-31", "test-slug")).toThrow(
+      'Cannot use day 31 for a month index 10 and slug "test-slug"'
+    );
+    //   Dec
+    expect(() => formatDate("2024-12-32", "test-slug")).toThrow(
+      'Cannot use day 32 for a month index 11 and slug "test-slug"'
+    );
+  });
+});

--- a/packages/blog2/src/functions/formatDate/index.ts
+++ b/packages/blog2/src/functions/formatDate/index.ts
@@ -1,0 +1,27 @@
+const DAY_DATES = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+export const formatDate = (dateString: string, slug: string) => {
+  const [yearString, monthString, dayString] = dateString.split("-");
+  const year = Number(yearString);
+  const monthIndex = Number(monthString) - 1;
+  if (monthIndex < 0 || monthIndex > 11) {
+    throw new Error(`Cannot use month index ${monthIndex} for slug "${slug}"`);
+  }
+
+  const dayDate = Number(dayString);
+  const maxDayDate = DAY_DATES[monthIndex];
+  if (dayDate < 1 || dayDate > maxDayDate) {
+    throw new Error(
+      `Cannot use day ${dayDate} for a month index ${monthIndex} and slug "${slug}"`
+    );
+  }
+
+  const date = new Date(year, monthIndex, dayDate);
+  const formattedDate = date.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+  return formattedDate;
+};

--- a/packages/blog2/src/functions/getPostBySlug/index.test.ts
+++ b/packages/blog2/src/functions/getPostBySlug/index.test.ts
@@ -11,7 +11,7 @@ describe(getPostBySlug.name, () => {
     expect(typeof content).toEqual("string");
 
     expect(data.title).toEqual(
-      "Scrollbar cus&shy;tomi&shy;sa&shy;tion" as UnsanitisedString
+      "Scrollbar cus&shy;tomi&shy;sa&shy;tion in CSS and JS" as UnsanitisedString
     );
     expect(data.date).toEqual("2018-10-04");
     expect(data.description).toEqual(
@@ -35,7 +35,9 @@ describe(getPostBySlug.name, () => {
 
     expect(typeof content).toEqual("string");
 
-    expect(data.title).toEqual("Type Challenges" as UnsanitisedString);
+    expect(data.title).toEqual(
+      "List of Type Challenges problems and solutions" as UnsanitisedString
+    );
     expect(data.date).toEqual("2021-04-04");
     expect(data.description).toEqual(
       "Easy, medium, hard and extreme step by step solutions to type challenges in TypeScript"

--- a/packages/blog2/src/functions/getPostUtcDate/index.test.ts
+++ b/packages/blog2/src/functions/getPostUtcDate/index.test.ts
@@ -3,15 +3,15 @@ import { Milliseconds } from "../../types/Milliseconds";
 import { getPostUtcDate } from "./";
 
 describe(getPostUtcDate.name, () => {
-  it("returns milliseconds for correct date", () => {
-    const actual = getPostUtcDate({ date: "2021-03-26" });
+  it("returns milliseconds", () => {
+    const actual = getPostUtcDate({ rawDate: "2021-03-26" });
     const expected = 1616716800000 as Milliseconds;
 
     expect(actual).toEqual(expected);
   });
 
-  it("throws error if date cannot be parsed", () => {
-    expect(() => getPostUtcDate({ date: "" })).toThrow(
+  it("throws error if raw date cannot be parsed", () => {
+    expect(() => getPostUtcDate({ rawDate: "" })).toThrow(
       "Post date format is incorrect: "
     );
   });

--- a/packages/blog2/src/functions/getPostUtcDate/index.ts
+++ b/packages/blog2/src/functions/getPostUtcDate/index.ts
@@ -2,12 +2,12 @@ import { Milliseconds } from "../../types/Milliseconds";
 import { PostType } from "../../types/PostType";
 
 export const getPostUtcDate = ({
-  date,
-}: Pick<PostType, "date">): Milliseconds => {
-  const milliseconds = Date.parse(date) as Milliseconds;
+  rawDate,
+}: Pick<PostType, "rawDate">): Milliseconds => {
+  const milliseconds = Date.parse(rawDate) as Milliseconds;
 
   if (isNaN(milliseconds)) {
-    throw new Error(`Post date format is incorrect: ${date}`);
+    throw new Error(`Post date format is incorrect: ${rawDate}`);
   }
 
   return milliseconds;

--- a/packages/blog2/src/hooks/useDarkMode/index.tsx
+++ b/packages/blog2/src/hooks/useDarkMode/index.tsx
@@ -1,43 +1,50 @@
-import { useCallback, useState } from "react"
+import { useCallback, useLayoutEffect, useState } from "react";
 
-export const DARK_MODE_STORAGE_KEY = "dark"
-export const DARK_MODE_CLASSNAME = "dark"
+export const DARK_MODE_STORAGE_KEY = "dark";
+export const DARK_MODE_CLASSNAME = "dark";
 
 export const getInitialDarkMode = () => {
   try {
-    const persistedDarkMode = localStorage.getItem(DARK_MODE_STORAGE_KEY)
+    const persistedDarkMode = localStorage.getItem(DARK_MODE_STORAGE_KEY);
     if (persistedDarkMode === null) {
-      return false
+      return false;
     }
 
-    return JSON.parse(persistedDarkMode)
+    return JSON.parse(persistedDarkMode);
   } catch (error) {
-    return false
+    return false;
   }
-}
+};
 
 const updateStorage = (darkMode: boolean) => {
-  localStorage.setItem(DARK_MODE_STORAGE_KEY, JSON.stringify(darkMode))
-}
+  localStorage.setItem(DARK_MODE_STORAGE_KEY, JSON.stringify(darkMode));
+};
 
 const updateDom = (darkMode: boolean) => {
-  document.body.classList.toggle(DARK_MODE_CLASSNAME, darkMode)
-}
+  document.body.classList.toggle(DARK_MODE_CLASSNAME, darkMode);
+};
 
 type UseDarkModeReturnValue = {
-  darkMode: boolean
-  toggle: VoidFunction
-}
+  initialising: boolean;
+  darkMode: boolean;
+  toggle: VoidFunction;
+};
 
 export const useDarkMode = (): UseDarkModeReturnValue => {
-  const [darkMode, setDarkMode] = useState(getInitialDarkMode())
+  const [darkMode, setDarkMode] = useState(false);
+  const [initialising, setInitialising] = useState(true);
 
   const toggle = useCallback(() => {
-    const nextDarkMode = !darkMode
-    updateStorage(nextDarkMode)
-    updateDom(nextDarkMode)
-    setDarkMode(nextDarkMode)
-  }, [darkMode, setDarkMode])
+    const nextDarkMode = !darkMode;
+    updateStorage(nextDarkMode);
+    updateDom(nextDarkMode);
+    setDarkMode(nextDarkMode);
+  }, [darkMode, setDarkMode]);
 
-  return { darkMode, toggle }
-}
+  useLayoutEffect(() => {
+    setDarkMode(getInitialDarkMode());
+    setInitialising(false);
+  }, []);
+
+  return { initialising, darkMode, toggle };
+};

--- a/packages/blog2/src/plugins/rssMetadata/generateRssXml/index.test.ts
+++ b/packages/blog2/src/plugins/rssMetadata/generateRssXml/index.test.ts
@@ -1,11 +1,12 @@
 import { expect } from "earljs";
-import { UnsanitisedString } from "../../../types/UnsanitisedString";
 import { ValidatedPostType } from "../../../types/ValidatedPostType";
 import { generateRssXml } from "./";
+import { SanitisedString } from "../../../types/SanitisedString";
 
 const SCROLLBAR_CUSTOMISATION_POST: ValidatedPostType = {
-  title: "Scrollbar cus&shy;tomi&shy;sa&shy;tion" as UnsanitisedString,
-  date: "2018-10-04",
+  title: "Scrollbar customisation" as SanitisedString,
+  rawDate: "2018-10-04",
+  date: "04 Oct 2018",
   description:
     "CSS support in different browser engines, hacks and tricks, JS libraries",
   labels: ["css", "javascript"],
@@ -15,8 +16,9 @@ const SCROLLBAR_CUSTOMISATION_POST: ValidatedPostType = {
 };
 
 const AMAZON_POST: ValidatedPostType = {
-  title: "Video player in Amazon" as UnsanitisedString,
-  date: "2019-12-17",
+  title: "Video player in Amazon" as SanitisedString,
+  rawDate: "2019-12-17",
+  date: "17 Dec 2019",
   description:
     "From video tag to the implementation, state machine, the way bundle is loaded, bundle names",
   labels: ["player"],

--- a/packages/blog2/src/plugins/rssMetadata/generateRssXmlItem/index.test.ts
+++ b/packages/blog2/src/plugins/rssMetadata/generateRssXmlItem/index.test.ts
@@ -1,12 +1,13 @@
 import { expect } from "earljs";
-import { UnsanitisedString } from "../../../types/UnsanitisedString";
 import { generateRssXmlItem } from "./";
+import { SanitisedString } from "../../../types/SanitisedString";
 
 describe(generateRssXmlItem.name, () => {
   it("returns xml item for validated post", () => {
     const actual = generateRssXmlItem({
-      title: "Scrollbar cus&shy;tomi&shy;sa&shy;tion" as UnsanitisedString,
-      date: "2018-10-04",
+      title: "Scrollbar customisation" as SanitisedString,
+      rawDate: "2018-10-04",
+      date: "04 Oct 2018",
       description:
         "CSS support in different browser engines, hacks and tricks, JS libraries",
       labels: ["css", "javascript"],

--- a/packages/blog2/src/plugins/rssMetadata/generateRssXmlItem/index.ts
+++ b/packages/blog2/src/plugins/rssMetadata/generateRssXmlItem/index.ts
@@ -1,6 +1,5 @@
 import { BLOG_META_INFO } from "../../../constants/BLOG_META_INFO";
 import { getPostUtcDate } from "../../../functions/getPostUtcDate";
-import { sanitiseHtml } from "../../../functions/sanitiseHtml";
 import { ValidatedPostType } from "../../../types/ValidatedPostType";
 import { toUtcString } from "../toUtcString";
 
@@ -11,7 +10,7 @@ export const generateRssXmlItem = (post: ValidatedPostType): string => {
   const link = `${url}${post.slug}`;
 
   return `<item>
-            <title><![CDATA[${sanitiseHtml(post.title)}]]></title>
+            <title><![CDATA[${post.title}]]></title>
             <description><![CDATA[${post.description}]]></description>
             <link>${link}</link>
             <guid isPermaLink="false">${link}</guid>

--- a/packages/blog2/src/static/getHomeStaticProps.ts
+++ b/packages/blog2/src/static/getHomeStaticProps.ts
@@ -17,7 +17,7 @@ export const getHomeStaticProps = async () => {
 
   const featuredPosts = posts.filter((post) => post.featured);
 
-  const latestPosts = posts.filter((post) => !post.featured).slice(0, 6);
+  const mostRecent10Posts = posts.filter((post) => !post.featured).slice(0, 11);
 
   const { apiKey, formId } = validateConvertKitParameters();
 
@@ -26,7 +26,7 @@ export const getHomeStaticProps = async () => {
       apiKey,
       formId,
       featuredPosts,
-      latestPosts,
+      mostRecent10Posts,
     },
   };
 };

--- a/packages/blog2/src/types/PostType.ts
+++ b/packages/blog2/src/types/PostType.ts
@@ -3,6 +3,7 @@ import { UnsanitisedString } from "./UnsanitisedString";
 
 export interface PostType {
   title: UnsanitisedString;
+  rawDate: string;
   date: string;
   slug: string;
   description: string;

--- a/packages/blog2/src/types/ValidatedPostType.ts
+++ b/packages/blog2/src/types/ValidatedPostType.ts
@@ -1,4 +1,7 @@
+import { StrictOmit } from "ts-essentials";
 import { PostPropsType } from "../components/pages/Post";
 import { PostType } from "./PostType";
+import { SanitisedString } from "./SanitisedString";
 
-export type ValidatedPostType = PostPropsType["post"] & Pick<PostType, "image">;
+export type ValidatedPostType = StrictOmit<PostPropsType["post"], "title"> &
+  Pick<PostType, "image"> & { title: SanitisedString };

--- a/packages/blog2/src/validators/validatePost.ts
+++ b/packages/blog2/src/validators/validatePost.ts
@@ -1,4 +1,5 @@
 import { KNOWN_LABELS } from "../constants/KNOWN_LABELS";
+import { formatDate } from "../functions/formatDate";
 import { sanitiseHtml } from "../functions/sanitiseHtml";
 import { PostType } from "../types/PostType";
 import { ValidatedPostType } from "../types/ValidatedPostType";
@@ -51,7 +52,7 @@ export const validatePost = ({
   }
 
   return {
-    date,
+    date: formatDate(date, slug),
     description,
     image,
     keywords,

--- a/packages/blog2/src/validators/validatePost.ts
+++ b/packages/blog2/src/validators/validatePost.ts
@@ -1,4 +1,5 @@
 import { KNOWN_LABELS } from "../constants/KNOWN_LABELS";
+import { sanitiseHtml } from "../functions/sanitiseHtml";
 import { PostType } from "../types/PostType";
 import { ValidatedPostType } from "../types/ValidatedPostType";
 
@@ -56,7 +57,7 @@ export const validatePost = ({
     keywords,
     labels,
     slug,
-    title,
+    title: sanitiseHtml(title),
     ...rest,
   };
 };

--- a/packages/blog2/src/validators/validatePost.ts
+++ b/packages/blog2/src/validators/validatePost.ts
@@ -52,6 +52,7 @@ export const validatePost = ({
   }
 
   return {
+    rawDate: date,
     date: formatDate(date, slug),
     description,
     image,

--- a/packages/blog2/styles/globals.css
+++ b/packages/blog2/styles/globals.css
@@ -130,6 +130,7 @@ h6 {
   margin-bottom: 1.5rem;
   line-height: 1rem;
   letter-spacing: -0.025em;
+  word-break: break-word;
 }
 
 h2,


### PR DESCRIPTION
## Summary

- Replace card grid with tables
- Change blog post names
- Replace sun/moon emojis with CSS styling
- Fix client/server error for `DarkModeToggle` by adding useLayoutEffect and initialising state

## Why

- To minimise the used space (card was too big, too much empty space which wasn't used)
- Names were too short so it could be very confusing for a reader to find the right one and even when found to understand what is the goal
- Moon/sun looked shifted on iPhone (potentially on Android) so now it's aligned to other platforms