### PR TITLE
style: 💅 Render Search Results separately from Input

### DIFF
--- a/packages/blog2/src/components/pages/Search/index.module.css
+++ b/packages/blog2/src/components/pages/Search/index.module.css
@@ -25,7 +25,7 @@
 
 .searchBar {
   width: 100%;
-  padding: 1rem 2.5rem 1rem 2rem;
+  padding: 1rem 2rem;
 
   background-color: var(--background-color);
   color: var(--color);
@@ -41,12 +41,8 @@
 }
 
 .searchElements {
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 2.5rem;
-  text-align: center;
+  font-style: italic;
+  padding: 1rem 2rem;
 }
 
 @media (max-width: 66.5rem) {

--- a/packages/blog2/src/components/pages/Search/index.tsx
+++ b/packages/blog2/src/components/pages/Search/index.tsx
@@ -113,7 +113,10 @@ export const Search = ({
             placeholder="What article are you looking for?"
             onInput={handleInputChange}
           />
-          <div className={styles.searchElements}>{filteredPosts.length}</div>
+        </div>
+        <div className={styles.searchElements}>
+          {filteredPosts.length} article{filteredPosts.length === 1 ? "" : "s"}{" "}
+          found
         </div>
 
         <table className={styles.table}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 patchedDependencies:
   bundlewatch@0.3.3:
     hash: uj6jncoatjcwavg7n4jojs6nni
@@ -110,6 +106,8 @@ importers:
       unified:
         specifier: 10.1.2
         version: 10.1.2
+
+  packages/blog2/dist: {}
 
   packages/habits:
     dependencies:
@@ -6568,3 +6566,7 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Summary

- Render Search Results separately from Input

## Examples:

### All articles

Before:
<img width="419" alt="Screenshot 2024-05-14 at 19 56 25" src="https://github.com/Beraliv/beraliv.dev/assets/2991847/615da4d1-3037-4b35-a6fc-f1407cf73a0f">
After:
<img width="421" alt="Screenshot 2024-05-14 at 19 56 14" src="https://github.com/Beraliv/beraliv.dev/assets/2991847/28469504-46cf-4af4-8adb-a0f9f05aff59">

### No articles

Before:
<img width="412" alt="Screenshot 2024-05-14 at 19 56 37" src="https://github.com/Beraliv/beraliv.dev/assets/2991847/6a76fec6-1c7c-492c-970d-c88fc9a0e219">
After:
<img width="415" alt="Screenshot 2024-05-14 at 19 56 34" src="https://github.com/Beraliv/beraliv.dev/assets/2991847/45dfad4c-d6b1-4f02-8af1-129345e1c320">

### 1 Article

Before:
<img width="412" alt="Screenshot 2024-05-14 at 19 56 52" src="https://github.com/Beraliv/beraliv.dev/assets/2991847/5ef9eaf2-b9d2-4a4f-9533-7f759a4cd9f3">
After:
<img width="399" alt="Screenshot 2024-05-14 at 19 56 57" src="https://github.com/Beraliv/beraliv.dev/assets/2991847/0a41dcf5-0df2-4da0-b5df-cec4d153f88e">