### PR TITLE
docs: 📹 add YouTube video link

### DIFF
--- a/packages/blog2/src/components/mdx/MdxYouTube/index.tsx
+++ b/packages/blog2/src/components/mdx/MdxYouTube/index.tsx
@@ -13,6 +13,7 @@ export const MdxYouTube = ({ href, title }: MdxYouTubeProps) => {
         src={href}
         title={title}
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerPolicy="strict-origin-when-cross-origin"
         allowFullScreen
       />
     </div>

--- a/packages/blog2/src/content/2021-12-10-advanced-types-holyjs-notes.md
+++ b/packages/blog2/src/content/2021-12-10-advanced-types-holyjs-notes.md
@@ -16,7 +16,7 @@ featured: true
 
 On November, 5, together with [Max](https://github.com/ColCh) we had a talk about [Advanced types in TypeScript on HolyJS](https://holyjs-moscow.ru/en/talks/advanced-types-in-typescript/).
 
-If you want to watch the talk in Russian, please follow the link:
+If you'd like to watch the entire talk in Russian, a recording is available on YouTube:
 
 <YouTube href="https://www.youtube.com/embed/KFWJGVDYZaw" title="Алексей Березин — Advanced types в TypeScript" />
 

--- a/packages/blog2/src/content/2023-12-21-story-of-unknown-low-tier-device-and-its-mse-issues-lvt-notes.md
+++ b/packages/blog2/src/content/2023-12-21-story-of-unknown-low-tier-device-and-its-mse-issues-lvt-notes.md
@@ -39,6 +39,10 @@ On October 3, I went to BBC Broadcasting House where LVT, [Upping the Auntie - S
 
 It was my first talk in English and I am very very happy with the way it went. I can say that it went much easier than the one in Russian.
 
+If you'd like to watch the entire talk in English, a recording is available on YouTube:
+
+<YouTube href="https://www.youtube.com/embed/yb6cTNCEGDo" title="A story of an unknown low-tier device and its MSE issues - Alexey Berezin | October 2023" />
+
 Let's walk through all materials that I have so far.
 
 ## Table of contents


### PR DESCRIPTION
## Summary

- Added `referrerPolicy="strict-origin-when-cross-origin"` to YouTube videos
- Added the link to my talk on LVT in BBC office - https://www.youtube.com/embed/yb6cTNCEGDo